### PR TITLE
EC2 fix subnet netmask to cidr prefix calculation for dns subnet check

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/util/Subnets.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/util/Subnets.java
@@ -152,7 +152,7 @@ public class Subnets extends ServiceJarDiscovery {
       this.subnetMask = InetAddresses.coerceToInteger( netmask );
       this.networkId = InetAddresses.coerceToInteger( address ) & this.subnetMask;
       this.subnet = InetAddresses.fromInteger( networkId );
-      this.prefix = ( int ) Math.round( Math.log( Integer.lowestOneBit( this.subnetMask ) ) / Math.log( 2 ) );
+      this.prefix = 32 - (( int ) Math.round( Math.log( Integer.lowestOneBit( this.subnetMask ) ) / Math.log( 2 ) ) );
     }
     
     Subnet( InetAddress subnet, int prefix ) throws UnknownHostException {


### PR DESCRIPTION
This pull request corrects the prefix calculation for system subnets so recursive dns requests are not spuriously rejected, this is a fix for sjones4/eucalyptus#5