### PR TITLE
S3 chunked writes must not block io threads on flush

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/ws/DelegatingChannel.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/ws/DelegatingChannel.java
@@ -1,0 +1,150 @@
+package com.eucalyptus.ws;
+
+import java.net.SocketAddress;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelConfig;
+import org.jboss.netty.channel.ChannelFactory;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelPipeline;
+
+/**
+ *
+ */
+abstract class DelegatingChannel implements Channel {
+
+  private final Channel delegate;
+
+  DelegatingChannel( final Channel delegate ) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Integer getId( ) {
+    return delegate.getId( );
+  }
+
+  @Override
+  public ChannelFactory getFactory( ) {
+    return delegate.getFactory( );
+  }
+
+  @Override
+  public Channel getParent( ) {
+    return delegate.getParent( );
+  }
+
+  @Override
+  public ChannelConfig getConfig( ) {
+    return delegate.getConfig( );
+  }
+
+  @Override
+  public ChannelPipeline getPipeline( ) {
+    return delegate.getPipeline( );
+  }
+
+  @Override
+  public boolean isOpen( ) {
+    return delegate.isOpen( );
+  }
+
+  @Override
+  public boolean isBound( ) {
+    return delegate.isBound( );
+  }
+
+  @Override
+  public boolean isConnected( ) {
+    return delegate.isConnected( );
+  }
+
+  @Override
+  public SocketAddress getLocalAddress( ) {
+    return delegate.getLocalAddress( );
+  }
+
+  @Override
+  public SocketAddress getRemoteAddress( ) {
+    return delegate.getRemoteAddress( );
+  }
+
+  @Override
+  public ChannelFuture write( final Object message ) {
+    return delegate.write( message );
+  }
+
+  @Override
+  public ChannelFuture write( final Object message, final SocketAddress remoteAddress ) {
+    return delegate.write( message, remoteAddress );
+  }
+
+  @Override
+  public ChannelFuture bind( final SocketAddress localAddress ) {
+    return delegate.bind( localAddress );
+  }
+
+  @Override
+  public ChannelFuture connect( final SocketAddress remoteAddress ) {
+    return delegate.connect( remoteAddress );
+  }
+
+  @Override
+  public ChannelFuture disconnect( ) {
+    return delegate.disconnect( );
+  }
+
+  @Override
+  public ChannelFuture unbind( ) {
+    return delegate.unbind( );
+  }
+
+  @Override
+  public ChannelFuture close( ) {
+    return delegate.close( );
+  }
+
+  @Override
+  public ChannelFuture getCloseFuture( ) {
+    return delegate.getCloseFuture( );
+  }
+
+  @Override
+  public int getInterestOps( ) {
+    return delegate.getInterestOps( );
+  }
+
+  @Override
+  public boolean isReadable( ) {
+    return delegate.isReadable( );
+  }
+
+  @Override
+  public boolean isWritable( ) {
+    return delegate.isWritable( );
+  }
+
+  @Override
+  public ChannelFuture setInterestOps( final int interestOps ) {
+    return delegate.setInterestOps( interestOps );
+  }
+
+  @Override
+  public ChannelFuture setReadable( final boolean readable ) {
+    return delegate.setReadable( readable );
+  }
+
+  @Override
+  public Object getAttachment( ) {
+    return delegate.getAttachment( );
+  }
+
+  @Override
+  public void setAttachment( final Object attachment ) {
+    delegate.setAttachment( attachment );
+  }
+
+  @Override
+  public int compareTo( final Channel o ) {
+    return delegate.compareTo( o );
+  }
+}

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/ws/DelegatingChannelHandlerContext.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/ws/DelegatingChannelHandlerContext.java
@@ -1,0 +1,69 @@
+package com.eucalyptus.ws;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelEvent;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelPipeline;
+
+/**
+ *
+ */
+abstract class DelegatingChannelHandlerContext implements ChannelHandlerContext {
+
+  private final ChannelHandlerContext delegate;
+
+  DelegatingChannelHandlerContext( final ChannelHandlerContext delegate ) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Channel getChannel( ) {
+    return delegate.getChannel( );
+  }
+
+  @Override
+  public ChannelPipeline getPipeline( ) {
+    return delegate.getPipeline( );
+  }
+
+  @Override
+  public String getName( ) {
+    return delegate.getName( );
+  }
+
+  @Override
+  public ChannelHandler getHandler( ) {
+    return delegate.getHandler( );
+  }
+
+  @Override
+  public boolean canHandleUpstream( ) {
+    return delegate.canHandleUpstream( );
+  }
+
+  @Override
+  public boolean canHandleDownstream( ) {
+    return delegate.canHandleDownstream( );
+  }
+
+  @Override
+  public void sendUpstream( final ChannelEvent e ) {
+    delegate.sendUpstream( e );
+  }
+
+  @Override
+  public void sendDownstream( final ChannelEvent e ) {
+    delegate.sendDownstream( e );
+  }
+
+  @Override
+  public Object getAttachment( ) {
+    return delegate.getAttachment( );
+  }
+
+  @Override
+  public void setAttachment( final Object attachment ) {
+    delegate.setAttachment( attachment );
+  }
+}

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/ws/Handlers.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/ws/Handlers.java
@@ -62,6 +62,7 @@
 
 package com.eucalyptus.ws;
 
+import static org.jboss.netty.channel.ChannelState.INTEREST_OPS;
 import java.net.SocketAddress;
 import com.eucalyptus.auth.AuthContextSupplier;
 import static com.eucalyptus.util.RestrictedTypes.findPolicyVendor;
@@ -175,7 +176,47 @@ public class Handlers {
   }
 
   private static ChannelHandler newChunkedWriteHandler( ) {
-    return new ChunkedWriteHandler( );
+    return new ChunkedWriteHandler( ) {
+      private void flush( final ChannelHandlerContext ctx ) {
+        try {
+          beforeRemove( ctx );
+        } catch ( final Exception e ) {
+          LOG.warn( "Unexpected exception while sending chunks.", e );
+        }
+      }
+
+      @Override
+      public void handleUpstream( final ChannelHandlerContext ctx, final ChannelEvent e ) throws Exception {
+        if ( e instanceof ChannelStateEvent ) {
+          final ChannelStateEvent cse = (ChannelStateEvent) e;
+          if ( INTEREST_OPS == cse.getState( ) ) {
+            // flush off the io thread to avoid blocking other channels
+            pipelineExecutionHandler( ).getExecutor( ).execute( () -> flush( ctx ) );
+            ctx.sendUpstream(e);
+            return;
+          }
+        }
+        super.handleUpstream( ctx, e );
+      }
+
+      @Override
+      public void handleDownstream( final ChannelHandlerContext ctx, final ChannelEvent e ) throws Exception {
+        final Channel channel = ctx.getChannel();
+        final boolean moveFlush = e instanceof MessageEvent && channel.isWritable( );
+        if ( moveFlush ) {
+          final Channel flushSuppressingChannel = new DelegatingChannel( channel ) {
+            @Override public boolean isWritable( ) { return false; }
+          };
+          super.handleDownstream( new DelegatingChannelHandlerContext( ctx ) {
+            @Override public Channel getChannel( ) { return flushSuppressingChannel; }
+          }, e );
+          // flush off the io thread to avoid blocking other channels
+          pipelineExecutionHandler( ).getExecutor( ).execute( () -> flush( ctx ) );
+        } else {
+          super.handleDownstream( ctx, e );
+        }
+      }
+    };
   }
 
   private static ChannelHandler newHttpResponseEncoder( ) {


### PR DESCRIPTION
This pull request addresses sjones4/eucalyptus#7 by moving the blocking flush of chunked data off of the netty io thread.

This issue occurs when the **_objectstorage_** and **_walrusbackend_** services are on the same host. In this deployment a single worker thread can end up servicing the clients request to both services. When the **_objectstorage_** worker thread blocks reading the input stream no work is performed for the **_walrusbackend_** so no more data can be produced, leading to a timeout.