### PR TITLE
Remove imaging-toolkit rpm httpd dependency

### DIFF
--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -383,7 +383,6 @@ Requires:     python-requests
 Requires:     coreutils
 Requires:     e2fsprogs
 Requires:     file
-Requires:     httpd
 Requires:     parted
 Requires:     util-linux
 
@@ -702,6 +701,9 @@ usermod -a -G libvirt eucalyptus || :
 
 
 %changelog
+* Thu Dec 28 2017 Steve Jones <steve.jones@appscale.com> - 4.4.2
+- Remove imaging-toolkit httpd dependency 
+
 * Fri Aug  4 2017 Garrett Holmstrom <gholms@dxc.com> - 4.4.2
 - Version bump (4.4.2)
 


### PR DESCRIPTION
Imaging toolkit does not use httpd, removing this dependency to reduce the image size.