### PR TITLE
S3 add connection close header for object gets

### DIFF
--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/handlers/ObjectStorageGETOutboundHandler.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/handlers/ObjectStorageGETOutboundHandler.java
@@ -192,6 +192,9 @@ public class ObjectStorageGETOutboundHandler extends ObjectStorageBasicOutboundH
             Channels.write(ctx, bodyWriteFuture, dataStream);
           }
         });
+        if ( !httpResponse.containsHeader( HttpHeaders.Names.CONNECTION ) ) {
+          httpResponse.addHeader( HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE );
+        }
       } else {
         writeFuture.addListener(ChannelFutureListener.CLOSE);
       }


### PR DESCRIPTION
This pull request addresses sjones4/eucalyptus#18 by adding a close header when closing the persistent http connection for object get requests.