### PR TITLE
Remove packaging for the (4.4) PopulateSnapPoints groovy script

### DIFF
--- a/clc/modules/block-storage/build.xml
+++ b/clc/modules/block-storage/build.xml
@@ -50,7 +50,6 @@
 		</copy>
 		<copy todir="${DESTDIR}${euca.lib.dir}" overwrite="true">
 			<fileset file="${jar.file}" />
-			<fileset file="src/main/java/com/eucalyptus/blockstorage/PopulateSnapPoints.groovy" />
 		</copy>
 	</target>
 </project>

--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -545,7 +545,6 @@ cp -Rp admin-tools/conf/* $RPM_BUILD_ROOT/%{_sysconfdir}/eucalyptus-admin
 
 %files sc
 %attr(-,eucalyptus,eucalyptus) %dir /var/lib/eucalyptus/volumes
-/usr/share/eucalyptus/PopulateSnapPoints.groovy
 
 
 %files cc
@@ -704,6 +703,9 @@ usermod -a -G libvirt eucalyptus || :
 
 
 %changelog
+* Tue Jul 24 2018 Steve Jones <steve.jones@appscale.com> - 5.0
+- Remove PopulateSnapPoints.groovy script
+
 * Thu May 10 2018 Steve Jones <steve.jones@appscale.com> - 4.4.4
 - Update libvirt requirement to 2.0.0+
 


### PR DESCRIPTION
The PopulateSnapPoints groovy script was 4.4 specific and is removed for 5.0. This pull request updates the packaging accordingly.