### PR TITLE
Empyrean service event propagation and shutdown errors

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/bootstrap/Hosts.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/bootstrap/Hosts.java
@@ -993,6 +993,10 @@ public class Hosts {
     return Hosts.list( DbFilter.INSTANCE );
   }
 
+  public static List<Host> listBooted( ) {
+    return Hosts.list( BootedFilter.INSTANCE );
+  }
+
   private static Host put( final Host newHost ) {
     return hostMap.put( newHost.getDisplayName( ), newHost );
   }

--- a/clc/modules/core/src/main/java/com/eucalyptus/component/Topology.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/component/Topology.java
@@ -1158,7 +1158,7 @@ public class Topology {
       @Override
       public ServiceConfiguration call( ) throws Exception {
         if ( Bootstrap.isShuttingDown( ) ) {
-          throw Exceptions.toUndeclared( "System is shutting down." );
+          throw new OrderlyTransitionException( "System is shutting down." );
         } else {
           final Long serviceStart = System.currentTimeMillis( );
           Logs.extreme( ).debug( EventRecord.here( Topology.class, EventType.DEQUEUE, function.toString( ), config.getFullName( ).toString( ),

--- a/clc/modules/core/src/main/java/com/eucalyptus/component/events/ServiceEvents.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/component/events/ServiceEvents.java
@@ -85,9 +85,6 @@ public class ServiceEvents {
         case STOPPED:
           msg = new StopServiceType( );
           break;
-//TODO:GRZE: Handle other state transitions here.
-//        case INITIALIZED:
-//        case LOADED:
         case NOTREADY:
           msg = new StartServiceType( );
           break;
@@ -96,7 +93,7 @@ public class ServiceEvents {
       }
       if ( msg != null ) {
         msg.getServices( ).add( TypeMappers.transform( config, ServiceId.class ) );
-        for ( Host h : Hosts.list( ) ) {
+        for ( Host h : Hosts.listBooted( ) ) {
           if ( !h.isLocalHost( ) && !h.getHostAddresses( ).contains( config.getInetAddress( ) ) ) {
             try {
               AsyncRequests.sendSync( ServiceConfigurations.createEphemeral( Empyrean.INSTANCE, h.getBindAddress( ) ), msg );


### PR DESCRIPTION
Empyrean updates to only propagate service events to booted hosts and suppress errors due to shutdown in progress.