### PR TITLE
Remove use of walrus response status, bindings set status appropriately by api

### DIFF
--- a/clc/modules/cloudformation/src/test/java/com/eucalyptus/cloudformation/CloudFormationBindingTest.groovy
+++ b/clc/modules/cloudformation/src/test/java/com/eucalyptus/cloudformation/CloudFormationBindingTest.groovy
@@ -268,7 +268,6 @@ class CloudFormationBindingTest extends QueryBindingTestSupport {
         }'''.stripIndent( ),
         CloudFormationQueryBinding.jsonWriter( ).withDefaultPrettyPrinter().writeValueAsString( new CloudFormationErrorResponse(
             effectiveUserId: '',
-            statusMessage: '',
             _epoch: 42,
             requestId: 'edbe8968-c437-11e4-bac0-25d29c2758a9',
             error: new Error(

--- a/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/msgs/ClusterServiceMessage.java
+++ b/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/msgs/ClusterServiceMessage.java
@@ -50,10 +50,6 @@ public interface ClusterServiceMessage extends BaseMessageMarker, IMarshallable,
 
   void setUserId( String userId );
 
-  String getStatusMessage( );
-
-  void setStatusMessage( String statusMessage );
-
   Boolean get_return( );
 
   void set_return( Boolean returnValue );

--- a/clc/modules/cluster-common/src/main/resources/cc-services.xml
+++ b/clc/modules/cluster-common/src/main/resources/cc-services.xml
@@ -42,7 +42,7 @@
   <mapping class="com.eucalyptus.cluster.common.msgs.ClusterServiceMessage" abstract="true">
     <value name="correlationId" get-method="getCorrelationId" set-method="setCorrelationId" usage="optional"/>
     <value name="userId" get-method="getUserId" set-method="setUserId" usage="optional" />
-    <value name="statusMessage" get-method="getStatusMessage" set-method="setStatusMessage" usage="optional" />
+    <structure name="statusMessage" usage="optional" />
     <value name="return" get-method="get_return" set-method="set_return" usage="optional" />
     <value name="epoch" get-method="get_epoch" set-method="set_epoch" usage="optional" />
     <collection get-method="get_services" set-method="set_services"

--- a/clc/modules/cluster-common/src/main/resources/cluster-binding-base.xml
+++ b/clc/modules/cluster-common/src/main/resources/cluster-binding-base.xml
@@ -32,7 +32,7 @@
   <mapping class="com.eucalyptus.cluster.common.msgs.CloudClusterMessage" abstract="true">
     <value name="correlationId" get-method="getCorrelationId" set-method="setCorrelationId" usage="optional"/>
     <value name="userId" get-method="getUserId" set-method="setUserId" usage="optional" />
-    <value name="statusMessage" get-method="getStatusMessage" set-method="setStatusMessage" usage="optional" />
+    <structure name="statusMessage" usage="optional" />
     <value name="return" get-method="get_return" set-method="set_return" usage="optional" />
     <value name="epoch" get-method="get_epoch" set-method="set_epoch" usage="optional" />
     <collection get-method="get_services" set-method="set_services"

--- a/clc/modules/cluster-common/src/main/resources/nc-binding-core.xml
+++ b/clc/modules/cluster-common/src/main/resources/nc-binding-core.xml
@@ -31,7 +31,7 @@
   <mapping class="com.eucalyptus.cluster.common.msgs.CloudNodeMessage" abstract="true">
     <value name="correlationId" get-method="getCorrelationId" set-method="setCorrelationId" usage="optional"/>
     <value name="userId" get-method="getUserId" set-method="setUserId" usage="optional" />
-    <value name="statusMessage" get-method="getStatusMessage" set-method="setStatusMessage" usage="optional" />
+    <structure name="statusMessage" usage="optional" />
     <value name="return" get-method="get_return" set-method="set_return" usage="optional" />
     <value name="epoch" get-method="get_epoch" set-method="set_epoch" usage="optional" />
     <collection get-method="get_services" set-method="set_services"

--- a/clc/modules/cluster-common/src/test/java/com/eucalyptus/cluster/common/ClusterBindingTest.groovy
+++ b/clc/modules/cluster-common/src/test/java/com/eucalyptus/cluster/common/ClusterBindingTest.groovy
@@ -106,6 +106,10 @@ class ClusterBindingTest {
     Binding binding = BindingManager.getBinding( 'eucalyptus_ucsb_edu' )
     OMElement messageOm = binding.toOM( new DescribeResourcesType( ) )
     println binding.fromOM( messageOm )
+    println binding.fromOM( """\
+        <DescribeResources xmlns="http://eucalyptus.ucsb.edu/">
+          <statusMessage>OK</statusMessage>
+        </DescribeResources>""".stripIndent( ) )
   }
 
   @Test

--- a/clc/modules/core/src/main/java/com/eucalyptus/util/Json.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/Json.java
@@ -291,7 +291,7 @@ public class Json {
   private interface BaseMessageMinimalMixin {
   }
 
-  @JsonIgnoreProperties( { "correlationId", "effectiveUserId", "reply", "statusMessage", "userId",
+  @JsonIgnoreProperties( { "correlationId", "effectiveUserId", "reply", "userId",
       "_disabledServices", "_notreadyServices", "_stoppedServices", "_epoch", "_services", "_return",
       "callerContext" } )
   private interface BaseMessageMixin {

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/handlers/IoSoapHandler.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/handlers/IoSoapHandler.java
@@ -128,7 +128,7 @@ public class IoSoapHandler extends ChannelDuplexHandler {
     if ( msg instanceof EucalyptusErrorMessageType ) {
       EucalyptusErrorMessageType errMsg = ( EucalyptusErrorMessageType ) msg;
       soapEnvelopeOption = Option.some( Pair.of(
-          Binding.createFault( errMsg.getSource( ), errMsg.getMessage( ), errMsg.getStatusMessage( ) ),
+          Binding.createFault( errMsg.getSource( ), errMsg.getMessage( ), errMsg.getMessage( ) ),
           org.jboss.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST.getCode( )
       ) );
     } else if ( msg instanceof ExceptionResponseType ) {

--- a/clc/modules/core/src/main/java/edu/ucsb/eucalyptus/msgs/BaseMessage.java
+++ b/clc/modules/core/src/main/java/edu/ucsb/eucalyptus/msgs/BaseMessage.java
@@ -44,8 +44,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.UUID;
 
-import javax.persistence.Transient;
-
 import org.apache.log4j.Logger;
 import org.jboss.netty.channel.ChannelEvent;
 import org.jboss.netty.channel.MessageEvent;
@@ -56,7 +54,6 @@ import org.jibx.runtime.JiBXException;
 
 import com.eucalyptus.auth.principal.Principals;
 import com.eucalyptus.auth.principal.User;
-import com.eucalyptus.binding.BindingManager;
 import com.eucalyptus.context.Contexts;
 import com.eucalyptus.empyrean.ServiceId;
 import com.eucalyptus.http.MappingHttpMessage;
@@ -69,14 +66,11 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 public class BaseMessage implements BaseMessageMarker {
-  @Transient
-  private static Logger        LOG       = Logger.getLogger( BaseMessage.class );
   private String               correlationId;
   private String               userId;
   private String               effectiveUserId;
   private BaseCallerContext    callerContext;
   private Boolean              _return   = true;
-  private String               statusMessage;
   private Integer              _epoch;                                           //NOTE:GRZE: intentionally violating naming conventions to avoid shadowing/conflicts
   private ArrayList<ServiceId> _services = Lists.newArrayList( );                //NOTE:GRZE: intentionally violating naming conventions to avoid shadowing/conflicts
   private ArrayList<ServiceId> _disabledServices = Lists.newArrayList( );                //NOTE:GRZE: intentionally violating naming conventions to avoid shadowing/conflicts
@@ -93,7 +87,6 @@ public class BaseMessage implements BaseMessageMarker {
     this( );
     this.userId = userId;
     this.effectiveUserId = userId;
-    this.statusMessage = null;
   }
   
   public BaseMessage( BaseMessage copy ) {
@@ -160,14 +153,6 @@ public class BaseMessage implements BaseMessageMarker {
   
   public void set_return( Boolean return1 ) {
     this._return = return1;
-  }
-  
-  public String getStatusMessage( ) {
-    return this.statusMessage;
-  }
-  
-  public void setStatusMessage( String statusMessage ) {
-    this.statusMessage = statusMessage;
   }
   
   @Deprecated
@@ -326,8 +311,7 @@ public class BaseMessage implements BaseMessageMarker {
     buf.append( this.getClass( ).getSimpleName( ) )
        .append( ":" ).append( this.correlationId )
        .append( ":return=" ).append( this.get_return( ) )
-       .append( ":epoch=" ).append( this.get_epoch( ) )
-       .append( ":status=" ).append( this.getStatusMessage( ) );
+       .append( ":epoch=" ).append( this.get_epoch( ) );
     return buf.toString( );
   }
   

--- a/clc/modules/core/src/main/java/edu/ucsb/eucalyptus/msgs/BaseMessages.java
+++ b/clc/modules/core/src/main/java/edu/ucsb/eucalyptus/msgs/BaseMessages.java
@@ -113,7 +113,7 @@ public class BaseMessages {
     return xmlMapper.readValue( reader, type );
   }
 
-  @JsonIgnoreProperties( { "correlationId", "effectiveUserId", "reply", "statusMessage", "userId" } )
+  @JsonIgnoreProperties( { "correlationId", "effectiveUserId", "reply", "userId" } )
   private static final class BaseMessageMixIn { }
 
   @JsonIgnoreProperties( { "webServiceErrorCode", "webServiceErrorMessage" } )

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactoryImpl.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactoryImpl.java
@@ -263,7 +263,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
     pot.setMetaData(gort.getMetaData());
     pot.setUser(requestUser);
     pot.setContentLength(gort.getSize().toString());
-    if (metadataDirective != null && "REPLACE".equals(metadataDirective)) {
+    if ("REPLACE".equals(metadataDirective)) {
       pot.setMetaData(request.getMetaData());
     } else if (metadataDirective == null || "".equals(metadataDirective) || "COPY".equals(metadataDirective)) {
       pot.setMetaData(gort.getMetaData());
@@ -283,7 +283,6 @@ public class ObjectFactoryImpl implements ObjectFactory {
     response.setVersionId(port.getVersionId());
     response.setKey(request.getDestinationObject());
     response.setBucket(request.getDestinationBucket());
-    response.setStatusMessage(port.getStatusMessage());
     response.setEtag(port.getEtag());
     response.setMetaData(port.getMetaData());
     // Last modified date in copy response is in ISO8601 format as per S3 API
@@ -538,7 +537,6 @@ public class ObjectFactoryImpl implements ObjectFactory {
 
     // Issue delete to backend
     DeleteObjectType deleteRequest;
-    DeleteObjectResponseType deleteResponse;
     LOG.trace("Deleting object " + entity.getObjectUuid() + ".");
     deleteRequest = new DeleteObjectType();
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactoryImpl.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactoryImpl.java
@@ -178,7 +178,6 @@ public class ObjectFactoryImpl implements ObjectFactory {
 
         @Override
         public CopyObjectResponseType call() throws Exception {
-          LOG.debug("calling copyObject");
           CopyObjectResponseType response;
           try {
             response = provider.copyObject(request);
@@ -190,7 +189,6 @@ public class ObjectFactoryImpl implements ObjectFactory {
               throw ex;
             }
           }
-          LOG.debug("Done with copyObject. " + response.getStatusMessage());
           return response;
         }
       };
@@ -326,9 +324,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
 
         @Override
         public PutObjectResponseType call() throws Exception {
-          LOG.debug("Putting data");
           PutObjectResponseType response = provider.putObject(putRequest, content);
-          LOG.debug("Done with put. Response status: " + response.getStatusMessage());
           return response;
         }
       };
@@ -612,11 +608,9 @@ public class ObjectFactoryImpl implements ObjectFactory {
       initRequest.setStorageClass(upload.getStorageClass());
       initRequest.setAccessControlList(upload.getAccessControlPolicy().getAccessControlList());
 
-      LOG.trace("Initiating MPU on backend");
       InitiateMultipartUploadResponseType response = provider.initiateMultipartUpload(initRequest);
       upload.setObjectModifiedTimestamp(response.getLastModified());
       upload.setUploadId(response.getUploadId());
-      LOG.trace("Done with MPU init on backend. " + response.getStatusMessage());
     } catch (Exception e) {
       LOG.error("InitiateMPU failure to backend for bucketuuid / objectuuid : " + upload.getBucket().getBucketUuid() + "/" + upload.getObjectUuid(),
           e);
@@ -684,9 +678,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
 
         @Override
         public UploadPartResponseType call() throws Exception {
-          LOG.trace("Putting data");
           UploadPartResponseType response = provider.uploadPart(putRequest, content);
-          LOG.trace("Done with put. " + response.getStatusMessage());
           return response;
         }
       };
@@ -770,7 +762,6 @@ public class ObjectFactoryImpl implements ObjectFactory {
         @Override
         public CompleteMultipartUploadResponseType call() throws Exception {
           CompleteMultipartUploadResponseType response = provider.completeMultipartUpload(commitRequest);
-          LOG.debug("Done with multipart upload. " + response.getStatusMessage());
           return response;
         }
       };

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactoryImpl.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactoryImpl.java
@@ -558,12 +558,7 @@ public class ObjectFactoryImpl implements ObjectFactory {
       deleteRequest.setKey(entity.getObjectUuid());
 
       try {
-        deleteResponse = provider.deleteObject(deleteRequest);
-        if (!(HttpResponseStatus.NO_CONTENT.equals(deleteResponse.getStatus()) || HttpResponseStatus.OK.equals(deleteResponse.getStatus()))) {
-          LOG.trace("Backend did not confirm deletion of " + deleteRequest.getBucket() + "/" + deleteRequest.getKey() + " via request: "
-              + deleteRequest.toString());
-          throw new Exception("Object could not be confirmed as deleted.");
-        }
+        provider.deleteObject(deleteRequest);
       } catch (S3Exception e) {
         if (HttpResponseStatus.NOT_FOUND.equals(e.getStatus())) {
           // Ok, fall through.

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -612,7 +612,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
     HeadBucketResponseType reply = request.getReply();
     reply.setBucket(bucket.getBucketName());
     reply.setStatus(HttpResponseStatus.OK);
-    reply.setStatusMessage("OK");
     reply.setTimestamp(new Date());
     setCorsInfo(request, reply, bucket);
     return reply;
@@ -676,7 +675,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
           reply.setStatus(HttpResponseStatus.OK);
           reply.setBucket(bucket.getBucketName());
           reply.setTimestamp(new Date());
-          reply.setStatusMessage("OK");
           LOG.trace("CorrelationId: " + request.getCorrelationId() + " Responding with " + reply.getStatus().toString());
           return reply;
         } catch (BucketAlreadyExistsException e) {
@@ -698,7 +696,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
             CreateBucketResponseType reply = request.getReply();
             reply.setStatus(HttpResponseStatus.OK);
             reply.setBucket(bucket.getBucketName());
-            reply.setStatusMessage("OK");
             LOG.trace("CorrelationId: " + request.getCorrelationId() + " Responding with " + reply.getStatus().toString());
             return reply;
           } else {
@@ -751,7 +748,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
     // Return success even if no deletion was needed. This is per s3-spec.
     DeleteBucketResponseType reply = request.getReply();
     reply.setStatus(HttpResponseStatus.NO_CONTENT);
-    reply.setStatusMessage("NoContent");
     LOG.trace("CorrelationId: " + request.getCorrelationId() + " Responding with " + reply.getStatus().toString());
     return reply;
   }
@@ -877,10 +873,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
     PostObjectResponseType reply = request.getReply();
     reply.setEtag(etag);
     reply.setLastModified(putObjectResponse.getLastModified());
-    reply.set_return(putObjectResponse.get_return());
     reply.setMetaData(putObjectResponse.getMetaData());
-    reply.setErrorCode(putObjectResponse.getErrorCode());
-    reply.setStatusMessage(putObjectResponse.getStatusMessage());
 
     String successActionRedirect = request.getSuccessActionRedirect();
     if (successActionRedirect != null) {
@@ -929,7 +922,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
       // Nothing to do, object doesn't exist. Return 204 per S3 spec
       DeleteObjectResponseType reply = request.getReply();
       reply.setStatus(HttpResponseStatus.NO_CONTENT);
-      reply.setStatusMessage("No Content");
       bucket = ensureBucketExists(request.getBucket());
       if ( bucket != null) {
         setCorsInfo(request, reply, bucket);
@@ -958,7 +950,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
 
       DeleteObjectResponseType reply = request.getReply();
       reply.setStatus(HttpResponseStatus.NO_CONTENT);
-      reply.setStatusMessage("No Content");
       if (responseEntity != null) {
         reply.setVersionId(responseEntity.getVersionId());
         if (responseEntity.getIsDeleteMarker() != null && responseEntity.getIsDeleteMarker())
@@ -2667,7 +2658,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
         UploadPartResponseType response = request.getReply();
         response.setLastModified(updatedEntity.getObjectModifiedTimestamp());
         response.setEtag(updatedEntity.geteTag());
-        response.setStatusMessage("OK");
         response.setSize(updatedEntity.getSize());
         setCorsInfo(request, response, bucket);
         return response;

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/S3ProviderClient.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/S3ProviderClient.java
@@ -576,7 +576,6 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
       // Save the owner info in response?
       reply.setBucket(request.getBucket());
       reply.setStatus(HttpResponseStatus.OK);
-      reply.setStatusMessage("OK");
     } catch (AmazonServiceException ex) {
       LOG.debug("Got service error from backend: " + ex.getMessage(), ex);
       throw S3ExceptionMapper.fromAWSJavaSDK(ex);
@@ -670,7 +669,6 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
     try {
       DeleteObjectResponseType reply = request.getReply();
       reply.setStatus(HttpResponseStatus.NO_CONTENT);
-      reply.setStatusMessage("NO CONTENT");
 
       internalS3Client = getS3Client(requestUser);
       AmazonS3Client s3Client = internalS3Client.getS3Client();
@@ -928,7 +926,6 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
       SetBucketLoggingConfigurationRequest loggingRequest = new SetBucketLoggingConfigurationRequest(request.getBucket(), config);
       s3Client.setBucketLoggingConfiguration(loggingRequest);
       reply.setStatus(HttpResponseStatus.OK);
-      reply.setStatusMessage("OK");
     } catch (AmazonServiceException e) {
       LOG.debug("Error from backend", e);
       throw S3ExceptionMapper.fromAWSJavaSDK(e);
@@ -1078,7 +1075,6 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
       s3Client.deleteVersion(request.getBucket(), request.getKey(), request.getVersionId());
       DeleteVersionResponseType reply = request.getReply();
       reply.setStatus(HttpResponseStatus.NO_CONTENT);
-      reply.setStatusMessage("NO CONTENT");
       return reply;
     } catch (AmazonServiceException e) {
       LOG.debug("Error from backend", e);

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/walrus/WalrusProviderClient.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/walrus/WalrusProviderClient.java
@@ -474,13 +474,7 @@ public class WalrusProviderClient extends S3ProviderClient {
   @Override
   public DeleteObjectResponseType deleteObject(DeleteObjectType request) throws S3Exception {
     try {
-      DeleteObjectResponseType response =
-          proxyRequest(request, com.eucalyptus.walrus.msgs.DeleteObjectType.class, com.eucalyptus.walrus.msgs.DeleteObjectResponseType.class);
-      // HACK: Remote Walrus cannot send HTTP status over wire. Setting the status here for now - EUCA-9425
-      if (response.getStatus() == null && response.getStatusMessage().equals("NO CONTENT")) {
-        response.setStatus(HttpResponseStatus.NO_CONTENT);
-      }
-      return response;
+      return proxyRequest(request, com.eucalyptus.walrus.msgs.DeleteObjectType.class, com.eucalyptus.walrus.msgs.DeleteObjectResponseType.class);
     } catch (EucalyptusCloudException e) {
       LOG.debug("Error response from WalrusBackend", e);
       throw mapWalrusExceptionToS3Exception(e);

--- a/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/InMemoryProvider.java
+++ b/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/InMemoryProvider.java
@@ -543,7 +543,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setContentDisposition(request.getContentDisposition());
       response.setLastModified(new Date());
       response.set_return(true);
-      LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
     } catch (Exception e) {
       LOG.debug("InMemory PutObject exception: ", e);
@@ -688,7 +687,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setVersionId("null");
       response.setLastModified(new Date().toString());
       response.set_return(true);
-      LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
     } catch (Exception e) {
       LOG.debug("InMemory PutObject exception: ", e);
@@ -740,7 +738,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setBucket(request.getBucket());
       response.setKey(request.getKey());
       response.set_return(true);
-      LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
     } catch (Exception e) {
       LOG.debug("InMemory PutObject exception: ", e);
@@ -799,7 +796,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setEtag(memObj.eTag);
       response.setLastModified(new Date());
       response.set_return(true);
-      LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
     } catch (Exception e) {
       LOG.debug("InMemory UploadPart exception: ", e);
@@ -869,7 +865,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setBucket(request.getBucket());
       response.setVersionId(finishedObj.versionId);
       response.set_return(true);
-      LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
     } catch (Exception e) {
       LOG.debug("InMemory abortMultipartUpload exception: ", e);
@@ -893,7 +888,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
 
       AbortMultipartUploadResponseType response = request.getReply();
       response.set_return(true);
-      LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
     } catch (Exception e) {
       LOG.debug("InMemory abortMultipartUpload exception: ", e);

--- a/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/InMemoryProvider.java
+++ b/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/InMemoryProvider.java
@@ -321,7 +321,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
     HeadBucketResponseType response = request.getReply();
     response.setBucket(request.getBucket());
     response.setStatus(HttpResponseStatus.OK);
-    response.setStatusMessage("OK");
     return response;
   }
 
@@ -368,7 +367,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
     }
 
     response.setStatus(HttpResponseStatus.OK);
-    response.setStatusMessage("OK");
     response.setBucket(request.getBucket());
     response.setTimestamp(new Date());
     return response;
@@ -387,7 +385,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
 
     DeleteBucketResponseType response = request.getReply();
     response.setStatus(HttpResponseStatus.NO_CONTENT);
-    response.setStatusMessage("NoContent");
 
     try {
       MemoryBucket b = getBucket(request.getBucket(), request.getEffectiveUserId());
@@ -545,7 +542,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setVersionId("null");
       response.setContentDisposition(request.getContentDisposition());
       response.setLastModified(new Date());
-      response.setStatusMessage("OK");
       response.set_return(true);
       LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
@@ -576,7 +572,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       default:
     }
     DeleteObjectResponseType response = request.getReply();
-    response.setStatusMessage("NoContent");
     response.setStatus(HttpResponseStatus.NO_CONTENT);
 
     try {
@@ -622,7 +617,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
     response.setSize(obj.size);
     response.setVersionId(obj.versionId);
     response.setDataInputStream(new ByteArrayInputStream(obj.content));
-    response.setStatusMessage("OK");
     response.setMetaData(obj.userMetadata==null?null: Lists.newArrayList(obj.userMetadata));
     return response;
   }
@@ -649,7 +643,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
     response.setLastModified(obj.modifiedDate);
     response.setSize(obj.size);
     response.setVersionId(obj.versionId);
-    response.setStatusMessage("OK");
     response.setMetaData(obj.userMetadata==null?null:Lists.newArrayList(obj.userMetadata));
     return response;
   }
@@ -694,7 +687,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setEtag(destObject.eTag);
       response.setVersionId("null");
       response.setLastModified(new Date().toString());
-      response.setStatusMessage("OK");
       response.set_return(true);
       LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
@@ -745,7 +737,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       bucket.uploads.put(memObj.uploadId, memObj);
       InitiateMultipartUploadResponseType response = request.getReply();
       response.setUploadId(memObj.uploadId);
-      response.setStatusMessage("OK");
       response.setBucket(request.getBucket());
       response.setKey(request.getKey());
       response.set_return(true);
@@ -807,7 +798,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setContentType(request.getContentType());
       response.setEtag(memObj.eTag);
       response.setLastModified(new Date());
-      response.setStatusMessage("OK");
       response.set_return(true);
       LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
@@ -878,7 +868,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       response.setKey(request.getKey());
       response.setBucket(request.getBucket());
       response.setVersionId(finishedObj.versionId);
-      response.setStatusMessage("OK");
       response.set_return(true);
       LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;
@@ -903,7 +892,6 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
       bucket.uploads.remove(request.getUploadId());
 
       AbortMultipartUploadResponseType response = request.getReply();
-      response.setStatusMessage("OK");
       response.set_return(true);
       LOG.debug("InMemory return response: " + response.getStatusMessage());
       return response;

--- a/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/ObjectStorageProviderClientTest.groovy
+++ b/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/ObjectStorageProviderClientTest.groovy
@@ -534,7 +534,7 @@ class ObjectStorageProviderClientTest {
     try {
       headObjRequest.setKey('nonexistentkey')
       objResponse = provider.headObject(headObjRequest)
-      fail('Should have thrown exception on HEAD of fake object: ' + objResponse.getStatusMessage())
+      fail('Should have thrown exception on HEAD of fake object: ' + objResponse)
     } catch (EucalyptusCloudException e) {
       println 'Correctly caught exception on HEAD of non-existent object ' + e
 

--- a/clc/modules/simpleworkflow/src/main/java/com/eucalyptus/simpleworkflow/SwfJsonUtils.java
+++ b/clc/modules/simpleworkflow/src/main/java/com/eucalyptus/simpleworkflow/SwfJsonUtils.java
@@ -122,7 +122,7 @@ public class SwfJsonUtils {
 
   // TODO:STEVE: add unit test to ensure we don't start using unexpected properties from BaseMessage
   // ignore properties of BaseMessage
-  @JsonIgnoreProperties( { "correlationId", "effectiveUserId", "reply", "statusMessage", "userId",
+  @JsonIgnoreProperties( { "correlationId", "effectiveUserId", "reply", "userId",
       "_disabledServices", "_notreadyServices", "_stoppedServices", "_epoch", "_services", "_return",
       "callerContext" } )
   private interface BindingMixIn {

--- a/clc/modules/walrus-common/src/main/java/com/eucalyptus/walrus/msgs/WalrusResponseType.java
+++ b/clc/modules/walrus-common/src/main/java/com/eucalyptus/walrus/msgs/WalrusResponseType.java
@@ -37,7 +37,6 @@ import edu.ucsb.eucalyptus.msgs.BaseMessage;
 public class WalrusResponseType extends BaseMessage {
 
   private BucketLogData logData;
-  private String statusMessage;
 
   public BucketLogData getLogData( ) {
     return logData;
@@ -45,13 +44,5 @@ public class WalrusResponseType extends BaseMessage {
 
   public void setLogData( BucketLogData logData ) {
     this.logData = logData;
-  }
-
-  public String getStatusMessage( ) {
-    return statusMessage;
-  }
-
-  public void setStatusMessage( String statusMessage ) {
-    this.statusMessage = statusMessage;
   }
 }

--- a/clc/modules/walrus-common/src/main/java/com/eucalyptus/walrus/msgs/WalrusResponseType.java
+++ b/clc/modules/walrus-common/src/main/java/com/eucalyptus/walrus/msgs/WalrusResponseType.java
@@ -28,7 +28,6 @@
  ************************************************************************/
 package com.eucalyptus.walrus.msgs;
 
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import com.eucalyptus.component.annotation.ComponentMessage;
 import com.eucalyptus.storage.msgs.BucketLogData;
 import com.eucalyptus.walrus.WalrusBackend;
@@ -38,7 +37,6 @@ import edu.ucsb.eucalyptus.msgs.BaseMessage;
 public class WalrusResponseType extends BaseMessage {
 
   private BucketLogData logData;
-  private HttpResponseStatus status;
   private String statusMessage;
 
   public BucketLogData getLogData( ) {
@@ -47,14 +45,6 @@ public class WalrusResponseType extends BaseMessage {
 
   public void setLogData( BucketLogData logData ) {
     this.logData = logData;
-  }
-
-  public HttpResponseStatus getStatus( ) {
-    return status;
-  }
-
-  public void setStatus( HttpResponseStatus status ) {
-    this.status = status;
   }
 
   public String getStatusMessage( ) {

--- a/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/WalrusFSManager.java
+++ b/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/WalrusFSManager.java
@@ -328,7 +328,6 @@ public class WalrusFSManager extends WalrusManager {
       throw new InternalErrorException("Failed to delete bucket=" + bucketName, e);
     }
 
-    reply.setStatus(HttpResponseStatus.NO_CONTENT);
     reply.setStatusMessage("NO CONTENT");
     return reply;
   }
@@ -699,7 +698,6 @@ public class WalrusFSManager extends WalrusManager {
     }
 
     // Always set the response to 204 NO CONTENT
-    reply.setStatus(HttpResponseStatus.NO_CONTENT);
     reply.setStatusMessage("NO CONTENT");
     return reply;
   }

--- a/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/WalrusFSManager.java
+++ b/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/WalrusFSManager.java
@@ -328,7 +328,6 @@ public class WalrusFSManager extends WalrusManager {
       throw new InternalErrorException("Failed to delete bucket=" + bucketName, e);
     }
 
-    reply.setStatusMessage("NO CONTENT");
     return reply;
   }
 
@@ -697,8 +696,6 @@ public class WalrusFSManager extends WalrusManager {
       throw new InternalErrorException("Failed to delete object-key=" + objectKey + ", bucket=" + bucketName, e);
     }
 
-    // Always set the response to 204 NO CONTENT
-    reply.setStatusMessage("NO CONTENT");
     return reply;
   }
 


### PR DESCRIPTION
Walrus use of response status is removed, individual bindings are responsible for setting this information.

The base message response status is also removed as it does not appear useful and required special handing in various bindings (to exclude it)