### PR TITLE
EC2 dns split horizon cluster lookup

### DIFF
--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/dns/SplitHorizonResolver.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/dns/SplitHorizonResolver.java
@@ -668,7 +668,7 @@ public abstract class SplitHorizonResolver extends DnsResolver {
         if ( !configurationOptional.isDefined( ) || Databases.isVolatile( ) ) {
           return lastLoaded.get( );
         } else try {
-          final Set<String> clusters = Components.services( ClusterController.class )
+          final Set<String> clusters = Components.servicesProviding( ClusterController.class )
               .map( ServiceConfiguration::getPartition )
               .toJavaSet( );
           final NetworkConfiguration configuration =

--- a/clc/modules/core/src/main/java/com/eucalyptus/component/Components.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/component/Components.java
@@ -138,6 +138,17 @@ public class Components {
     return IdToComponent.INSTANCE.apply( componentId );
   }
 
+  public static Stream<ServiceConfiguration> servicesProviding( final Class<? extends ComponentId> componentId ) {
+    try {
+      return Stream.ofAll( ComponentIds.list( ) )
+          .filter( comp -> comp.hasApi( componentId ) )
+          .map( Components::lookup )
+          .flatMap( Component::services );
+    } catch ( NoSuchElementException e ) {
+      return Stream.empty( );
+    }
+  }
+
   public static Stream<ServiceConfiguration> services( final Class<? extends ComponentId> componentId ) {
     try {
       return Stream.ofAll( lookup( componentId ).services( ) );


### PR DESCRIPTION
EC2 instances split horizon recursive dns functionality is broken due to the cluster api/implementation split. We now lookup cluster service implementations based on the api class.