### PR TITLE
Imaging worker httpd dependency not needed

### DIFF
--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -407,7 +407,6 @@ Requires:     python-requests
 Requires:     coreutils
 Requires:     e2fsprogs
 Requires:     file
-Requires:     httpd
 Requires:     parted
 Requires:     util-linux
 


### PR DESCRIPTION
Remove httpd dependency which pulls in large os logos package.