### PR TITLE
Load balancing use consistent format for metadata

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/util/Strings.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/Strings.java
@@ -30,10 +30,12 @@ package com.eucalyptus.util;
 
 import java.util.Collections;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
@@ -354,6 +356,24 @@ public class Strings {
    */
   public static CompatFunction<Object,String> toStringFunction() {
     return StringerFunctions.TOSTRING;
+  }
+
+  /**
+   * Wrap a string returning function for null safety.
+   *
+   * <P>The returned function will return an empty string in place of
+   * any null values.</P>
+   *
+   * @return The wrapped function
+   */
+  public static <T> CompatFunction<T,String> nonNull( final Function<T,String> function ) {
+    return new CompatFunction<T,String>( ) {
+      @Nullable
+      @Override
+      public String apply( @Nullable final T t ) {
+        return MoreObjects.firstNonNull( function.apply( t ), "" );
+      }
+    };
   }
 
   /**

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancerPolicies.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancerPolicies.java
@@ -45,7 +45,6 @@ import org.apache.log4j.Logger;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionResource;
 import com.eucalyptus.loadbalancing.LoadBalancerBackendServerDescription.LoadBalancerBackendServerDescriptionCoreView;
-import com.eucalyptus.loadbalancing.LoadBalancerBackendServerDescription.LoadBalancerBackendServerDescriptionEntityTransform;
 import com.eucalyptus.loadbalancing.LoadBalancerListener.LoadBalancerListenerCoreView;
 import com.eucalyptus.loadbalancing.LoadBalancerListener.PROTOCOL;
 import com.eucalyptus.loadbalancing.LoadBalancerPolicyAttributeDescription.LoadBalancerPolicyAttributeDescriptionCoreView;
@@ -66,6 +65,7 @@ import com.eucalyptus.loadbalancing.service.LoadBalancingException;
 import com.eucalyptus.loadbalancing.service.PolicyTypeNotFoundException;
 import com.eucalyptus.system.BaseDirectory;
 import com.eucalyptus.util.Exceptions;
+import com.eucalyptus.util.Strings;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
@@ -73,6 +73,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.base.Predicate;
 /**
@@ -746,6 +747,7 @@ public class LoadBalancerPolicies {
       }
       final PolicyAttributeDescriptions descs = new PolicyAttributeDescriptions();
       descs.setMember((ArrayList<PolicyAttributeDescription>) attrDescs);
+      descs.getMember().sort(Ordering.natural().onResultOf(Strings.nonNull(PolicyAttributeDescription::getAttributeName)));
       policy.setPolicyAttributeDescriptions(descs);
       return policy;
     }

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancers.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancers.java
@@ -32,6 +32,7 @@ package com.eucalyptus.loadbalancing;
 import static com.eucalyptus.loadbalancing.LoadBalancer.Scheme;
 import static com.eucalyptus.loadbalancing.common.LoadBalancingMetadata.LoadBalancerMetadata;
 import static com.eucalyptus.util.RestrictedTypes.QuantityMetricFunction;
+import static com.eucalyptus.util.Strings.nonNull;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -780,6 +781,9 @@ public class LoadBalancers {
 						}
 					}));
 		}
+		if (desc.getBackendInstances()!=null) {
+			desc.getBackendInstances().getMember().sort(Ordering.natural().onResultOf(nonNull(BackendInstance::getInstanceId)));
+		}
 
 		/// availability zones
 		desc.setAvailabilityZones(new AvailabilityZones());
@@ -817,6 +821,7 @@ public class LoadBalancers {
 									}
 								}
 							})));
+							pnames.getMember().sort(Ordering.natural());
 							policiesOfListener.addAll(pnames.getMember());
 							desc.setPolicyNames(pnames);
 							return desc;
@@ -845,11 +850,13 @@ public class LoadBalancers {
 											}
 										})
 								));
+								desc.getPolicyNames().getMember().sort(Ordering.natural());
 								policiesForBackendServer.addAll(desc.getPolicyNames().getMember());
 								return desc;
 							}
 						})
 				));
+				desc.getBackendServerDescriptions().getMember().sort(Ordering.natural().onResultOf(BackendServerDescription::getInstancePort));
 			}
 		} catch (final Exception ex) {
 			;
@@ -885,6 +892,7 @@ public class LoadBalancers {
 		}
 		final PolicyDescriptions policyDescs = new PolicyDescriptions();
 		policyDescs.setMember((ArrayList<PolicyDescription>) policies);
+		policyDescs.getMember().sort(Ordering.natural().onResultOf(nonNull(PolicyDescription::getPolicyName)));
 		desc.setPolicyDescriptions(policyDescs);
 
 		return desc;


### PR DESCRIPTION
Sort load balancer data so identical configurations have the same string representations.