### PR TITLE
Euare policy parser test fix string condition op registration

### DIFF
--- a/clc/modules/euare/src/test/java/com/eucalyptus/auth/euare/policy/EuarePolicyParserTest.java
+++ b/clc/modules/euare/src/test/java/com/eucalyptus/auth/euare/policy/EuarePolicyParserTest.java
@@ -50,7 +50,7 @@ public class EuarePolicyParserTest {
 
   @BeforeClass
   public static void beforeClass( ) {
-    Conditions.registerCondition( "StringEquals", StringEquals.class, false );
+    Conditions.registerCondition( "StringEquals", StringEquals.class, true );
     Keys.registerKeyProvider( new RegisteredKeyProvider( ) );
     Keys.registerKeyProvider( new OpenIDConnectKeyProvider( ) );
   }


### PR DESCRIPTION
Fix incorrect string condition op registration in euare policy parser test as this could cause failures in other tests depending on execution order.