### PR TITLE
EC2 swap formatting revert

### DIFF
--- a/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/callback/ResourceStateCallback.java
+++ b/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/callback/ResourceStateCallback.java
@@ -58,7 +58,6 @@ public class ResourceStateCallback extends StateUpdateMessageCallback<Cluster, D
   
   /**
    * @see com.eucalyptus.util.async.MessageCallback#fire(edu.ucsb.eucalyptus.msgs.BaseMessage)
-   * @param reply
    */
   @Override
   public void fire( final DescribeResourcesResponseType reply ) {
@@ -74,7 +73,6 @@ public class ResourceStateCallback extends StateUpdateMessageCallback<Cluster, D
   
   /**
    * @see StateUpdateMessageCallback#fireException(com.eucalyptus.util.async.FailedRequestException)
-   * @param t
    */
   @Override
   public void fireException( FailedRequestException t ) {
@@ -89,11 +87,7 @@ public class ResourceStateCallback extends StateUpdateMessageCallback<Cluster, D
           vmType.getMemory( ),
           vmType.getDisk( ),
           vmType.getCpu( ),
-          "sda1" ) {
-        {
-          this.setSwap( "sda2", 512 * 1024l * 1024l, "none" );
-        }
-      } );
+          "sda1" ) );
     }
     return describeResourcesType;
   }

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypes.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypes.java
@@ -109,9 +109,13 @@ public class VmTypes {
                       initial = "m1.small" )
   public static String         DEFAULT_TYPE_NAME        = "m1.small";
 
-  @ConfigurableField( description = "Format first ephemeral disk by defaut with ext3", initial = "true",
+  @ConfigurableField( description = "Format first ephemeral disk by default with ext3", initial = "true",
       changeListener = PropertyChangeListeners.IsBoolean.class)
   public static Boolean        FORMAT_EPHEMERAL_STORAGE = true;
+
+  @ConfigurableField( description = "Format swap disk by default. The property will be deprecated in next major release.",
+      initial = "false", changeListener = PropertyChangeListeners.IsBoolean.class)
+  public static Boolean        FORMAT_SWAP = false;
 
   @Deprecated
   //GRZE: this and all its references must be removed to complete the vm type support
@@ -600,7 +604,7 @@ public class VmTypes {
     public VmTypeInfo apply( VmType arg0 ) {
       return new VmTypeInfo( arg0.getName( ), arg0.getMemory( ), arg0.getDisk( ), arg0.getCpu( ), "sda1" ) {
         {
-          this.setSwap( "sda3", VmTypes.SWAP_SIZE_BYTES, "none" );
+          this.setSwap( "sda3", VmTypes.SWAP_SIZE_BYTES, VmTypes.FORMAT_SWAP ? "swap" : "none" );
         }
       };
     }

--- a/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
@@ -844,7 +844,6 @@ public class StaticDatabasePropertyEntry extends AbstractPersistent {
           "bootstrap.webservices.client_pool_total_mem",
           "cloudformation.swf_client_config",
           "cloud.vmstate.network_metadata_refresh_time",
-          "cloud.vmtypes.format_swap",
           "reporting.data_collection_enabled",
           "reporting.default_size_time_size_unit",
           "reporting.default_size_time_time_unit",

--- a/storage/diskutil.c
+++ b/storage/diskutil.c
@@ -778,6 +778,39 @@ int diskutil_unloop(const char *lodev)
 }
 
 //!
+//! Format a partition as a swap.
+//!
+//! @param[in] lodev
+//! @param[in] size_bytes
+//!
+//! @return EUCA_OK on success or the following error codes:
+//!         \li EUCA_ERROR: if any error occured.
+//!         \li EUCA_INVALID_ERROR: if any parameter does not meet the preconditions.
+//!
+//! @pre The lodev parameters must not be NULL.
+//!
+//! @post On success, the partition is formatted as swap.
+//!
+int diskutil_mkswap(const char *lodev, const long long size_bytes)
+{
+    char *output = NULL;
+
+    if (lodev) {
+        output = pruntf(TRUE, "%s %s %s %lld", helpers_path[ROOTWRAP], helpers_path[MKSWAP], lodev, size_bytes / 1024);
+        if (!output) {
+            LOGERROR("cannot format partition on '%s' as swap\n", lodev);
+            return (EUCA_ERROR);
+        }
+
+        EUCA_FREE(output);
+        return (EUCA_OK);
+    }
+
+    LOGWARN("cannot format partition as swap. lodev=%s\n", SP(lodev));
+    return (EUCA_INVALID_ERROR);
+}
+
+//!
 //!
 //!
 //! @param[in] lodev

--- a/storage/diskutil.c
+++ b/storage/diskutil.c
@@ -103,6 +103,7 @@ enum {
     LOSETUP,
     MKDIR,
     MKEXT3,
+    MKSWAP,
     PARTED,
     TUNE2FS,
     LASTHELPER
@@ -145,6 +146,7 @@ static char *helpers[LASTHELPER] = {
     "losetup",
     "mkdir",
     "mkfs.ext3",
+    "mkswap",
     "parted",
     "tune2fs",
 };

--- a/storage/diskutil.h
+++ b/storage/diskutil.h
@@ -122,6 +122,7 @@ sem *diskutil_get_loop_sem(void);
 int diskutil_loop_check(const char *path, const char *lodev);
 int diskutil_loop(const char *path, const long long offset, char *lodev, int lodev_size);
 int diskutil_unloop(const char *lodev);
+int diskutil_mkswap(const char *lodev, const long long size_bytes);
 int diskutil_mkfs(const char *lodev, const long long size_bytes);
 int diskutil_tune(const char *lodev);
 int diskutil_sectors(const char *path, const int part, long long *first, long long *last);

--- a/storage/vbr.c
+++ b/storage/vbr.c
@@ -664,6 +664,8 @@ static int parse_rec(virtualBootRecord * vbr, virtualMachine * vm, ncMetadata * 
         vbr->format = NC_FORMAT_EXT3;
     } else if (strstr(vbr->formatName, "ntfs") == vbr->formatName) {
         vbr->format = NC_FORMAT_NTFS;
+    } else if (strstr(vbr->formatName, "swap") == vbr->formatName) {
+        vbr->format = NC_FORMAT_SWAP;
     } else {
         LOGERROR("failed to parse resource format '%s'\n", vbr->formatName);
         return (EUCA_ERROR);
@@ -1167,6 +1169,9 @@ blockmap map = { BLOBSTORE_SNAPSHOT, BLOBSTORE_ZERO, {blob:NULL}
     case NC_FORMAT_EXT2:              //! @TODO distinguish ext2 and ext3!
     case NC_FORMAT_EXT3:
         format = diskutil_mkfs(dest_dev, a->size_bytes);
+        break;
+    case NC_FORMAT_SWAP:
+        format = diskutil_mkswap(dest_dev, a->size_bytes);
         break;
     default:
         LOGERROR("[%s] format of type %d/%s is NOT IMPLEMENTED\n", a->instanceId, vbr->format, vbr->formatName);

--- a/util/eucalyptus.h
+++ b/util/eucalyptus.h
@@ -192,6 +192,7 @@
 #define CONFIG_NC_CACHE_SIZE                    "NC_CACHE_SIZE"
 #define CONFIG_NC_WORK_SIZE                     "NC_WORK_SIZE"
 #define CONFIG_NC_OVERHEAD_SIZE                 "NC_WORK_OVERHEAD_SIZE"
+#define CONFIG_NC_SWAP_SIZE                     "SWAP_SIZE"
 #define CONFIG_SAVE_INSTANCES                   "MANUAL_INSTANCES_CLEANUP"
 #define CONFIG_CONCURRENT_DISK_OPS              "CONCURRENT_DISK_OPS"
 #define CONFIG_SC_REQUEST_TIMEOUT               "SC_REQUEST_TIMEOUT"


### PR DESCRIPTION
This reverts the removal of a swap formatting option for ec2 paravirtual instances. We are not removing ext3 formatting for the first ephemeral disk so no security benefit can be gained from removing the functionality at this time (i.e. we would still need to access instance disks)