### PR TITLE
euctl should not treat swf client configuration as json documents

### DIFF
--- a/admin-tools/eucalyptus_admin/commands/properties/euctl.py
+++ b/admin-tools/eucalyptus_admin/commands/properties/euctl.py
@@ -45,8 +45,6 @@ from eucalyptus_admin.commands.properties.modifypropertyvalue import \
 
 PROPERTY_TYPES = {'authentication.ldap_integration_configuration': 'json',
                   'cloud.network.network_configuration': 'json',
-                  'cloudformation.swf_client_config': 'json',
-                  'cloudformation.swf_workflow_worker_config': 'json',
                   'region.region_configuration': 'json'}
 
 


### PR DESCRIPTION
Various services have short json values for swf configuration, these are now handled consistently.