### PR TITLE
Admin script for releasing credentials clcadmin-release-credentials

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -102,6 +102,7 @@ install: build
 	@$(INSTALL) -m 755 clcadmin-copy-keys $(DESTDIR)$(sbindir)/clusteradmin-copy-keys
 	@$(INSTALL) -m 755 clcadmin-impersonate-user $(DESTDIR)$(sbindir)/clcadmin-impersonate-user
 	@$(INSTALL) -m 755 clcadmin-initialize-cloud $(DESTDIR)$(sbindir)/clcadmin-initialize-cloud
+	@$(INSTALL) -m 755 clcadmin-release-credentials $(DESTDIR)$(sbindir)/clcadmin-release-credentials
 	@$(INSTALL) -m 755 clusteradmin-register-nodes $(DESTDIR)$(sbindir)/clusteradmin-register-nodes
 	@$(INSTALL) -m 755 clusteradmin-register-nodes $(DESTDIR)$(sbindir)/clusteradmin-deregister-nodes
 	@$(INSTALL) -d $(DESTDIR)$(etcdir)/eucalyptus/cloud.d/elb-security-policy

--- a/tools/clcadmin-release-credentials
+++ b/tools/clcadmin-release-credentials
@@ -1,0 +1,59 @@
+#!/usr/bin/python -tt
+#
+# Copyright 2018 AppScale Systems, Inc
+#
+# Use of this source code is governed by a BSD-2-Clause
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/BSD-2-Clause
+
+"""
+%(prog)s clears environment credentials for administrative impersonation
+of accounts (users) or other usage.  Output is in a form suitable for
+running inside an `eval' command.
+"""
+
+from __future__ import unicode_literals
+
+import argparse
+import pipes
+import sys
+
+
+def parse_cli_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '-a', dest='all', action='store_true',
+        help='clear all environment, not just credentials')
+    return parser.parse_args()
+
+
+def print_result(clear_all):
+    for var in (
+            'AWS_ACCESS_KEY', 'AWS_ACCESS_KEY_ID',
+            'AWS_CREDENTIAL_EXPIRATION', 'AWS_CREDENTIAL_FILE',
+            'AWS_SECRET_ACCESS_KEY', 'AWS_SECRET_KEY', 'AWS_SECURITY_TOKEN',
+            'AWS_SESSION_TOKEN', 'EC2_ACCESS_KEY', 'EC2_PRIVATE_KEY',
+            'EC2_SECRET_KEY', 'EC2_USER_ID'):
+        fmt = 'unset {0};'
+        print fmt.format(var)
+    if clear_all:
+        for var in (
+                'AWS_AUTO_SCALING_URL', 'AWS_CLOUDFORMATION_URL',
+                'AWS_CLOUDWATCH_URL', 'AWS_ELB_URL', 'AWS_IAM_URL',
+                'EC2_URL', 'EUCA_BOOTSTRAP_URL', 'EUCA_PROPERTIES_URL',
+                'EUCA_REPORTING_URL', 'S3_URL', 'TOKEN_URL'):
+            fmt = 'unset {0};'
+            print fmt.format(var)
+    print
+    print '# If you can read this, rerun this program with eval:'
+    print '#     eval `{0}`'.format(
+        ' '.join(pipes.quote(arg) for arg in sys.argv))
+
+
+def main():
+    args = parse_cli_args()
+    print_result(args.all)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add `clcadmin-release-credentials` to release credentials obtained via `clcadmin-assume-system-credentials` or `clcadmin-impersonate-user`.