### PR TITLE
CloudFormation yaml template format

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/template/TemplateParser.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/template/TemplateParser.java
@@ -44,7 +44,12 @@ import com.eucalyptus.cloudformation.resources.ResourceResolverManager;
 import com.eucalyptus.cloudformation.template.dependencies.CyclicDependencyException;
 import com.eucalyptus.cloudformation.template.dependencies.DependencyManager;
 import com.eucalyptus.util.Json;
+import com.eucalyptus.util.Strings;
+import com.eucalyptus.util.Yaml;
+import com.eucalyptus.util.Yaml.TaggedTokenFilter;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -60,7 +65,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.PatternSyntaxException;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
 
 
 /**
@@ -137,18 +145,27 @@ public class TemplateParser {
   private static final String DEFAULT_TEMPLATE_VERSION = "2010-09-09";
   private static final String[] validTemplateVersions = new String[] {DEFAULT_TEMPLATE_VERSION};
 
-  public Template parse(String templateBody, List<Parameter> userParameters, List<String> capabilities, PseudoParameterValues pseudoParameterValues, String effectiveUserId, boolean enforceStrictResourceProperties) throws CloudFormationException {
-    Template template = new Template();
-    template.setResourceInfoMap(Maps.<String, ResourceInfo>newLinkedHashMap());
+  private static final ObjectReader reader = Yaml.mapper( new CloudFormationTaggedTokenFilter( ) ).reader( );
+
+  public JsonNode parseTemplateText( final String template ) throws ValidationErrorException {
     JsonNode templateJsonNode;
     try {
-      templateJsonNode = Json.parse( templateBody );
+      templateJsonNode = template.trim().startsWith( "{" ) ?
+          Json.parse( template ) :
+          Yaml.parse( reader, template );
     } catch (IOException ex) {
       throw new ValidationErrorException(ex.getMessage());
     }
     if (!templateJsonNode.isObject()) {
       throw new ValidationErrorException("Template body is not a JSON object");
     }
+    return templateJsonNode;
+  }
+
+  public Template parse(String templateBody, List<Parameter> userParameters, List<String> capabilities, PseudoParameterValues pseudoParameterValues, String effectiveUserId, boolean enforceStrictResourceProperties) throws CloudFormationException {
+    Template template = new Template();
+    template.setResourceInfoMap(Maps.<String, ResourceInfo>newLinkedHashMap());
+    JsonNode templateJsonNode = parseTemplateText( templateBody );
     template.setTemplateBody(templateBody);
     addPseudoParameters(template, pseudoParameterValues);
     buildResourceMap(template, templateJsonNode, enforceStrictResourceProperties);
@@ -238,15 +255,7 @@ public class TemplateParser {
   public GetTemplateSummaryResult getTemplateSummary(String templateBody, List<Parameter> userParameters, PseudoParameterValues pseudoParameterValues, String effectiveUserId, boolean enforceStrictResourceProperties) throws CloudFormationException {
     Template template = new Template();
     template.setResourceInfoMap(Maps.<String, ResourceInfo>newLinkedHashMap());
-    JsonNode templateJsonNode;
-    try {
-      templateJsonNode = Json.parse(templateBody);
-    } catch (IOException ex) {
-      throw new ValidationErrorException(ex.getMessage());
-    }
-    if (!templateJsonNode.isObject()) {
-      throw new ValidationErrorException("Template body is not a JSON object");
-    }
+    JsonNode templateJsonNode = parseTemplateText( templateBody );
     template.setTemplateBody(templateBody);
     addPseudoParameters(template, pseudoParameterValues);
     buildResourceMap(template, templateJsonNode, enforceStrictResourceProperties);
@@ -1357,8 +1366,16 @@ public class TemplateParser {
     if (fnAttMatcher.isMatch()) {
       IntrinsicFunctions.GET_ATT.validateArgTypesWherePossible(fnAttMatcher);
       // we have a match against a "ref"...
-      String refName = jsonNode.get(FunctionEvaluation.FN_GET_ATT).get(0).asText();
-      String attName = jsonNode.get(FunctionEvaluation.FN_GET_ATT).get(1).asText();
+      String refName;
+      String attName;
+      final JsonNode key = jsonNode.get(FunctionEvaluation.FN_GET_ATT);
+      if ( key.isTextual( ) ) {
+        refName = Strings.substringBefore( ".", key.asText( ) );
+        attName = Strings.substringAfter( ".", key.asText( ) );
+      } else {
+        refName = key.get( 0 ).asText( );
+        attName = key.get( 1 ).asText( );
+      }
       // Not sure why, but AWS validates attribute types even in Conditions
       if (resourceInfoMap.containsKey(refName)) {
         ResourceInfo resourceInfo = resourceInfoMap.get(refName);
@@ -1383,15 +1400,7 @@ public class TemplateParser {
 
   public Map<String,ParameterType> getParameterTypeMap(String templateBody) throws CloudFormationException {
     Map<String, ParameterType> returnVal = Maps.newHashMap();
-    JsonNode templateJsonNode;
-    try {
-      templateJsonNode = Json.parse( templateBody );
-    } catch (IOException ex) {
-      throw new ValidationErrorException(ex.getMessage());
-    }
-    if (!templateJsonNode.isObject()) {
-      throw new ValidationErrorException("Template body is not a JSON object");
-    }
+    JsonNode templateJsonNode = parseTemplateText( templateBody );
     JsonNode parametersJsonNode = JsonHelper.checkObject(templateJsonNode, TemplateParser.TemplateSection.Parameters.toString());
     if (parametersJsonNode != null) {
       for (String parameterKey : Lists.newArrayList(parametersJsonNode.fieldNames())) {
@@ -1406,5 +1415,42 @@ public class TemplateParser {
     return returnVal;
   }
 
+  private static class CloudFormationTaggedTokenFilter implements TaggedTokenFilter{
+    private final Function<String,Boolean> tagTest = io.vavr.collection.HashSet.of(
+        "Base64",
+        "Cidr",
+        "FindInMap",
+        "GetAtt",
+        "GetAZs",
+        "Join",
+        "Select",
+        "Split",
+        "Sub",
+        "Ref",
+        "And",
+        "Equals",
+        "If",
+        "Not",
+        "Or"
+    );
+
+    @Override
+    public Tuple2<io.vavr.collection.List<Tuple2<JsonToken, String>>, io.vavr.collection.List<Tuple2<JsonToken, String>>> filterTag(
+        final String tag,
+        final JsonToken token
+    ) {
+      Tuple2<io.vavr.collection.List<Tuple2<JsonToken, String>>, io.vavr.collection.List<Tuple2<JsonToken, String>>> result = null;
+      if ( tagTest.apply( tag ) ) {
+        String name = "Ref".equals( tag ) ? tag : "Fn::" + tag;
+        result = Tuple.of(
+            io.vavr.collection.List.of(
+                Tuple.of( JsonToken.START_OBJECT, null ),
+                Tuple.of( JsonToken.FIELD_NAME, name ) ),
+            io.vavr.collection.List.of(
+                Tuple.of( JsonToken.END_OBJECT, null ) ) );
+      }
+      return result;
+    }
+  };
 }
 

--- a/clc/modules/core/build.gradle
+++ b/clc/modules/core/build.gradle
@@ -61,6 +61,7 @@ dependencies {
   api 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
   api 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6'
   api 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.6'
+  api 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6'
   api 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.9.6'
   api('com.github.sjones4:glisten:0.3.euca'){
     exclude module: 'groovy-all' // we include the indy variant

--- a/clc/modules/core/src/main/java/com/eucalyptus/util/Yaml.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/Yaml.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.util;
+
+import java.io.CharArrayReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecycler;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.collection.List;
+import io.vavr.collection.Set;
+import io.vavr.collection.Stream;
+import io.vavr.control.Option;
+
+
+/**
+ * YAML 1.1 utilities
+ *
+ * http://yaml.org/type/index.html
+ * http://yaml.org/spec/current.html (i.e. v1.1)
+ */
+public class Yaml {
+  private static final TaggedTokenFilter noopFilter = ( tag, token ) -> null;
+  private static final ObjectMapper mapper = mapper( );
+  private static final ObjectReader reader = mapper.reader( );
+
+  /**
+   * Types for yaml.org, e.g. tag:yaml.org,2002:str
+   *
+   *   !!map
+   *   !!omap
+   *   !!pairs
+   *   !!set
+   *   !!seq
+   *
+   *   !!binary
+   *   !!bool
+   *   !!float
+   *   !!int
+   *   !!merge
+   *   !!null
+   *   !!str
+   *   !!timestamp
+   *   !!value
+   *   !!yaml
+   *
+   * we allow a subset of the above.
+   */
+  private static final Set<String> PERMITTED_TAGS = Stream.of(
+      "map",
+      "seq",
+      "bool",
+      "float",
+      "int",
+      "str"
+  ).map( Strings.prepend( "tag:yaml.org,2002:" ) ).toSet( );
+
+  public static JsonNode parse( final InputStream yamlStream ) throws IOException {
+    return parse( reader, yamlStream );
+  }
+
+  public static JsonNode parse( final ObjectReader reader, final InputStream yamlStream ) throws IOException {
+    if ( yamlStream == null ) throw new IOException( "Null" );
+    final JsonParser parser = reader.getFactory( ).createParser( yamlStream );
+    return parse( parser );
+  }
+
+  public static JsonNode parse( final String yamlText ) throws IOException {
+    return parse( reader, yamlText );
+  }
+
+  public static JsonNode parse( final ObjectReader reader, final String yamlText ) throws IOException {
+    if ( yamlText == null ) throw new IOException( "Null" );
+    final JsonParser parser = reader.getFactory( ).createParser( new StringReader( yamlText ) {
+      @Override public String toString() { return "yaml"; } // overridden for better source in error message
+    } );
+    return parse( parser );
+  }
+
+  public static JsonNode parse( final JsonParser parser ) throws IOException {
+    if ( parser == null ) throw new IOException( "Null" );
+    final JsonNode node = reader.readTree( parser );
+    if ( node == null ) {
+      throw new IOException( "No content at " + parser.getCurrentLocation( ) );
+    }
+    boolean trailingContent;
+    try {
+      trailingContent = parser.nextToken( ) != null;
+    } catch ( IOException e ) {
+      trailingContent = true;
+    }
+    if ( trailingContent ) {
+      throw new IOException( "Unexpected trailing content at " + parser.getCurrentLocation( ) );
+    }
+    return node;
+  }
+
+  /**
+   * Get a new mapper
+   */
+  public static ObjectMapper mapper( ) {
+    return mapper(noopFilter);
+  }
+
+  /**
+   * Get a new mapper
+   */
+  public static ObjectMapper mapper( final TaggedTokenFilter filter ) {
+    return new ObjectMapper(new EucaYAMLFactory(filter));
+  }
+
+  /**
+   * Filter a token stream during document parse.
+   */
+  public interface TaggedTokenFilter {
+    /**
+     * Filter a tagged token by adding tokens/names to the stream before or after a tagged token.
+     *
+     * @param tag The application specific tag to process
+     * @param token The JsonToken with the tag
+     * @return null if tag not supported, empty lists for no changes
+     */
+    Tuple2<List<Tuple2<JsonToken,String>>, List<Tuple2<JsonToken,String>>> filterTag( String tag, JsonToken token );
+  }
+
+  /**
+   * Factory allowing customization of yaml parser configuration
+   */
+  private static class EucaYAMLFactory extends YAMLFactory {
+    private static final long serialVersionUID = 1L;
+    private final TaggedTokenFilter tokenFilter;
+
+    private EucaYAMLFactory( final TaggedTokenFilter tokenFilter ) {
+      this.tokenFilter = tokenFilter;
+    }
+
+    @Override
+    protected YAMLParser _createParser( final InputStream in, final IOContext ctxt ) throws IOException {
+      return new EucaYAMLParser(tokenFilter, ctxt, _getBufferRecycler(), _parserFeatures,
+          _yamlParserFeatures, _objectCodec, _createReader(in, null, ctxt));
+    }
+
+    @Override
+    protected YAMLParser _createParser( final Reader r, final IOContext ctxt ) {
+      return new EucaYAMLParser(tokenFilter, ctxt, _getBufferRecycler(), _parserFeatures,
+          _yamlParserFeatures, _objectCodec, r);
+    }
+
+    @Override
+    protected YAMLParser _createParser( final char[] data, final int offset, final int len, final IOContext ctxt,
+                                        final boolean recyclable ) {
+      return new EucaYAMLParser(tokenFilter, ctxt, _getBufferRecycler(), _parserFeatures,
+          _yamlParserFeatures, _objectCodec, new CharArrayReader(data, offset, len));
+    }
+
+    @Override
+    protected YAMLParser _createParser( final byte[] data, final int offset, final int len,
+                                        final IOContext ctxt ) throws IOException {
+      return new EucaYAMLParser(tokenFilter, ctxt, _getBufferRecycler(), _parserFeatures,
+          _yamlParserFeatures, _objectCodec, _createReader(data, offset, len, null, ctxt));
+    }
+  }
+
+  /**
+   * Parser that disallows aliases and unsafe yaml functionality
+   */
+  private static class EucaYAMLParser extends YAMLParser {
+    private final Deque<List<Tuple2<JsonToken,String>>> tokensStack = new ArrayDeque<>( );
+    private final Deque<Tuple2<JsonToken,String>> tokenStack = new ArrayDeque<>( );
+    private final TaggedTokenFilter tokenFilter;
+    private Option<String> currentNameOverride = Option.none();
+
+    public EucaYAMLParser( final TaggedTokenFilter tokenFilter, final IOContext ctxt, final BufferRecycler br,
+                           final int parserFeatures, final int formatFeatures, final ObjectCodec codec,
+                           final Reader reader ) {
+      super( ctxt, br, parserFeatures, formatFeatures, codec, reader );
+      this.tokenFilter = tokenFilter;
+    }
+
+    @Override
+    public String getCurrentName( ) throws IOException {
+      return currentNameOverride.isDefined( ) ? currentNameOverride.get( ) : super.getCurrentName( );
+    }
+
+    @Override
+    public JsonToken nextToken( ) throws IOException {
+      JsonToken token;
+
+      if( tokenStack.isEmpty( ) ) {
+        currentNameOverride = Option.none( );
+        token = super.nextToken( );
+        if ( isCurrentAlias( ) ) {
+          throw new IOException( "Alias not supported" );
+        }
+        final JsonToken processingToken = token;
+        final String typeId = getTypeId( );
+        List<Tuple2<JsonToken,String>> pushTokens = List.empty( );
+        if ( typeId != null && !typeId.startsWith( "tag:" ) ) {
+          final Tuple2<List<Tuple2<JsonToken,String>>, List<Tuple2<JsonToken,String>>> filterResult =
+              tokenFilter.filterTag( typeId, token );
+          if ( filterResult == null ) {
+            throw new IOException( "Unsupported tag: " + typeId );
+          }
+          if ( !filterResult._1( ).isEmpty( ) ) {
+            final Tuple2<JsonToken,String> append = Tuple.of(token, getCurrentName());
+            token = filterResult._1( ).get( 0 )._1( );
+            currentNameOverride = Option.some( filterResult._1( ).get( 0 )._2( ) );
+            filterResult._1( ).slice( 1, filterResult._1( ).size( ) ).forEach( tokenStack::addLast );
+            tokenStack.addLast( append );
+          }
+          if ( !filterResult._2( ).isEmpty( ) ) {
+            if ( processingToken.isStructStart( ) ) {
+              pushTokens = filterResult._2( );
+            } else {
+              filterResult._2( ).forEach( tokenStack::addLast );
+            }
+          }
+        } else if ( typeId != null && !isPermittedTag( typeId ) ) {
+          throw new IOException( "Unsupported type: " + typeId );
+        }
+        if ( processingToken !=null && processingToken.isStructStart( ) &&
+            (!pushTokens.isEmpty( ) || !tokensStack.isEmpty( ) ) ) {
+          tokensStack.addFirst( pushTokens );
+        } else if ( token != null && token.isStructEnd( ) && !tokensStack.isEmpty() ) {
+          tokensStack.pop( ).forEach( tokenStack::addLast );
+        }
+      } else {
+        final Tuple2<JsonToken,String> tokenAndName = tokenStack.pop( );
+        token = tokenAndName._1( );
+        currentNameOverride = Option.some( tokenAndName._2( ) );
+      }
+      return token;
+    }
+
+    private boolean isPermittedTag( final String tag ) {
+      return PERMITTED_TAGS.contains( tag );
+    }
+  }
+}

--- a/clc/modules/core/src/test/java/com/eucalyptus/util/YamlTest.groovy
+++ b/clc/modules/core/src/test/java/com/eucalyptus/util/YamlTest.groovy
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.util
+
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.JsonNode
+import io.vavr.Tuple as VTuple
+import io.vavr.Tuple2 as VTuple2
+import io.vavr.collection.List as VList
+import org.junit.Assert
+import org.junit.Test
+
+/**
+ *
+ */
+class YamlTest {
+
+  @Test
+  void testParseWithObject( ) {
+    Yaml.parse( '{}' )
+  }
+
+  @Test
+  void testParseWithText( ) {
+    Yaml.parse( '"asfd"' )
+  }
+
+  @Test
+  void testParseWithDocument( ) {
+    Yaml.parse( '''\
+    ---
+    Key1: Value1
+    Key2:
+      - ListValue1
+      - ListValue2
+    ...
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testParseWithTaggedDocument( ) {
+    Yaml.parse( '''\
+    ---
+    Key1: !!str Value1
+    Key2: !!seq
+      - !!str ListValue1
+      - !!str ListValue2
+    ...
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testParseVersion10Directive( ) {
+    Yaml.parse( '''\
+    %YAML 1.0
+    ---
+    Key1: Value1
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testParseVersion11Directive( ) {
+    Yaml.parse( '''\
+    %YAML 1.1
+    ---
+    Key1: Value1
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testParseVersion12Directive( ) {
+    Yaml.parse( '''\
+    %YAML 1.2
+    ---
+    Key1: Value1
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testParseTagDirective( ) {
+    Yaml.parse( '''\
+    %TAG !yaml! tag:yaml.org,2002:
+    ---
+    !yaml!str "foo"
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testRandomDirective( ) {
+    Yaml.parse( '''\
+    %BLAH YAML rulez
+    ---
+    a: b
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testParseUnsafe( ) {
+    Yaml.parse( '''\
+    !!java.io.FileOutputStream [/tmp/unsafe.txt]
+    a: b
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testParseMultipleDocuments( ) {
+    Yaml.parse( '''\
+    ---
+    a: b
+
+    ---
+    c: d
+    ---
+    e: f
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testParseMultipleDocumentsExplicitEnd( ) {
+    Yaml.parse( '''\
+    ---
+    a: b
+
+    ...
+    ---
+    c: d
+    ...
+    ---
+    e: f
+    ...
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testParseAlias( ) {
+    Yaml.parse( '''\
+    &A [ *A ]
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testParseHashMerge( ) {
+    Object foo = Yaml.parse( '''\
+    defaults: &defaults
+      a: b
+    development:
+      <<: *defaults
+      c: d
+    '''.stripIndent( ) )
+    print foo
+  }
+
+  @Test(expected = IOException)
+  void testParseTag( ) {
+    Yaml.parse( '''\
+    !TagGoesHere example
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testBasicTags( ) {
+    Yaml.parse( '''\
+    explicit string: !!str abc
+    explicit integer: !!int 12
+    explicit float: !!float 12.1
+    explicit bool: !!bool true
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testBasic( ) {
+    Yaml.parse( '''\
+    implicit string: abc
+    implicit integer: 12
+    implicit float: 12.1
+    implicit bool: false
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testBasicCollectionsTag( ) {
+    Yaml.parse( '''\
+    list1: !!seq [ a, b, c ]
+    list2: !!seq
+      - a
+      - b
+      - c
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testBasicCollections( ) {
+    Yaml.parse( '''\
+    list1: [ a, b, c ]
+    list2:
+      - a
+      - b
+      - c
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testBinaryShortCanonical( ) {
+    Yaml.parse( '''\
+    canonical: !!binary "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
+    description:
+     The binary value above is a tiny arrow encoded as a gif image.
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testBinaryShort( ) {
+    Yaml.parse( '''\
+    generic: !!binary |
+     R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5
+     OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
+     +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
+     AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
+    description:
+     The binary value above is a tiny arrow encoded as a gif image.
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testBinaryCanonical( ) {
+    Yaml.parse( '''\
+    canonical: !!binary "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
+    description:
+     The binary value above is a tiny arrow encoded as a gif image.
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testBinary( ) {
+    Yaml.parse( '''\
+    generic: !!binary |
+     R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5
+     OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+
+     +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC
+     AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=
+    description:
+     The binary value above is a tiny arrow encoded as a gif image.
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testTimestampsAsStrings( ) {
+    Yaml.parse( '''\
+    canonical: 2001-12-15T02:59:43.1Z
+    iso8601: 2001-12-14t21:59:43.10-05:00
+    spaced: 2001-12-14 21:59:43.10 -5
+    date: 2002-12-14
+    '''.stripIndent( ) )
+  }
+
+  @Test(expected = IOException)
+  void testTimestamps( ) {
+    Yaml.parse( '''\
+    canonical: !!timestamp 2001-12-15T02:59:43.1Z
+    iso8601: !!timestamp 2001-12-14t21:59:43.10-05:00
+    spaced: !!timestamp 2001-12-14 21:59:43.10 -5
+    date: !!timestamp 2002-12-14
+    '''.stripIndent( ) )
+  }
+
+  @Test
+  void testFilter( ) {
+    JsonNode node1 = Yaml.parse( '''\
+    a:
+      foo: b
+    '''.stripIndent( ) )
+
+    final Yaml.TaggedTokenFilter filter = new Yaml.TaggedTokenFilter() {
+      @Override
+      VTuple2<VList<VTuple2<JsonToken,String>>, VList<VTuple2<JsonToken,String>>> filterTag(final String tag, final JsonToken token) {
+        return tag == 'foo' ? VTuple.of(
+            VList.of( VTuple.of( JsonToken.START_OBJECT, '' ), VTuple.of( JsonToken.FIELD_NAME, 'foo' ) ),
+            VList.of( VTuple.of( JsonToken.END_OBJECT, '' ) ) ) :
+            null
+      }
+    }
+    JsonNode node2 = Yaml.parse( Yaml.mapper( filter ).reader( ), '''\
+    a: !foo b
+    '''.stripIndent( ) )
+
+    Assert.assertEquals( 'Nodes', node1, node2 )
+  }
+
+  @Test
+  void testFilterArray( ) {
+    JsonNode node1 = Yaml.parse( '''\
+    a:
+      foo: [ b, c, d ]
+    '''.stripIndent( ) )
+
+    final Yaml.TaggedTokenFilter filter = new Yaml.TaggedTokenFilter() {
+      @Override
+      VTuple2<VList<VTuple2<JsonToken,String>>, VList<VTuple2<JsonToken,String>>> filterTag(final String tag, final JsonToken token) {
+        return tag == 'foo' ? io.vavr.Tuple.of(
+            VList.of( VTuple.of( JsonToken.START_OBJECT, '' ), VTuple.of( JsonToken.FIELD_NAME, 'foo' ) ),
+            VList.of( VTuple.of( JsonToken.END_OBJECT, '' ) ) ) :
+            null
+      }
+    }
+    JsonNode node2 = Yaml.parse( Yaml.mapper( filter ).reader( ), '''\
+    a: !foo [ b, c, d ]
+    '''.stripIndent( ) )
+
+    Assert.assertEquals( 'Nodes', node1, node2 )
+  }
+
+  @Test
+  void testFilterArrayNesting( ) {
+    JsonNode node1 = Yaml.parse( '''\
+    a:
+      foo:
+        - b
+        - foo: c
+        - [ d ]
+    '''.stripIndent( ) )
+
+    println node1
+
+    final Yaml.TaggedTokenFilter filter = new Yaml.TaggedTokenFilter() {
+      @Override
+      VTuple2<VList<VTuple2<JsonToken,String>>, VList<VTuple2<JsonToken,String>>> filterTag(final String tag, final JsonToken token) {
+        return tag == 'foo' ? io.vavr.Tuple.of(
+            VList.of( VTuple.of( JsonToken.START_OBJECT, '' ), VTuple.of( JsonToken.FIELD_NAME, 'foo' ) ),
+            VList.of( VTuple.of( JsonToken.END_OBJECT, '' ) ) ) :
+            null
+      }
+    }
+    JsonNode node2 = Yaml.parse( Yaml.mapper( filter ).reader( ), '''\
+    a: !foo [ b, !foo c, [ d ] ]
+    '''.stripIndent( ) )
+
+    println node2
+
+    Assert.assertEquals( 'Nodes', node1, node2 )
+  }
+}


### PR DESCRIPTION
CloudFormation yaml template format support. Uses jacksons yaml support so the only required evaluation time changes are to `Fn::GetAtt` for support of a single text parameter, e.g. `Resource.Attribute`.