### PR TITLE
EC2 : Update instance types

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingAutoScalingGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingAutoScalingGroupResourceAction.java
@@ -416,11 +416,6 @@ public class AWSAutoScalingAutoScalingGroupResourceAction extends StepBasedResou
       public Integer getTimeout() {
         return (int) MAX_SIGNAL_TIMEOUT;
       }
-    };
-    // no retries on most steps
-    @Override
-    public Integer getTimeout( ) {
-      return null;
     }
   }
 
@@ -510,10 +505,6 @@ public class AWSAutoScalingAutoScalingGroupResourceAction extends StepBasedResou
         return true;
       }
       return false;
-    }
-
-    public Integer getTimeout( ) {
-      return null;
     }
   }
 
@@ -789,12 +780,6 @@ public class AWSAutoScalingAutoScalingGroupResourceAction extends StepBasedResou
       public Integer getTimeout() {
         return MAX_SIGNAL_TIMEOUT;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingLaunchConfigurationResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingLaunchConfigurationResourceAction.java
@@ -162,12 +162,6 @@ public class AWSAutoScalingLaunchConfigurationResourceAction extends StepBasedRe
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -184,12 +178,6 @@ public class AWSAutoScalingLaunchConfigurationResourceAction extends StepBasedRe
         return action;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
   }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingScalingPolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingScalingPolicyResourceAction.java
@@ -129,12 +129,6 @@ public class AWSAutoScalingScalingPolicyResourceAction extends StepBasedResource
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -163,12 +157,6 @@ public class AWSAutoScalingScalingPolicyResourceAction extends StepBasedResource
         return action;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
   }
 
   private enum UpdateNoInterruptionSteps implements UpdateStep {
@@ -196,11 +184,6 @@ public class AWSAutoScalingScalingPolicyResourceAction extends StepBasedResource
         newAction.info.setCreatedEnoughToDelete(true);
         newAction.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(newAction.info.getPhysicalResourceId())));
         return newAction;
-      }
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     };
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudFormationStackResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudFormationStackResourceAction.java
@@ -405,12 +405,6 @@ public class AWSCloudFormationStackResourceAction extends StepBasedResourceActio
       }
     };
 
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
-
     private static boolean alreadyDeletedOrNeverCreated(AWSCloudFormationStackResourceAction action, ServiceConfiguration configuration) throws Exception {
       if (!Boolean.TRUE.equals(action.info.getCreatedEnoughToDelete())) return true;
       // First see if stack exists or has been deleted
@@ -585,12 +579,6 @@ public class AWSCloudFormationStackResourceAction extends StepBasedResourceActio
         newAction.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(newAction.info.getPhysicalResourceId())));
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -646,11 +634,6 @@ public class AWSCloudFormationStackResourceAction extends StepBasedResourceActio
         // Wait as long as necessary for stacks
         return MAX_TIMEOUT;
       }
-    };
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
   private static StatusAndReason getStackStatusAndReason(AWSCloudFormationStackResourceAction action, ServiceConfiguration configuration) throws Exception {
@@ -735,11 +718,6 @@ public class AWSCloudFormationStackResourceAction extends StepBasedResourceActio
         // Wait as long as necessary for stacks
         return MAX_TIMEOUT;
       }
-    };
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -792,12 +770,6 @@ public class AWSCloudFormationStackResourceAction extends StepBasedResourceActio
         // Wait as long as necessary for stacks
         return MAX_TIMEOUT;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudFormationWaitConditionHandleResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudFormationWaitConditionHandleResourceAction.java
@@ -126,12 +126,6 @@ public class AWSCloudFormationWaitConditionHandleResourceAction extends StepBase
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -159,12 +153,6 @@ public class AWSCloudFormationWaitConditionHandleResourceAction extends StepBase
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudFormationWaitConditionResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudFormationWaitConditionResourceAction.java
@@ -171,11 +171,6 @@ public class AWSCloudFormationWaitConditionResourceAction extends StepBasedResou
         action.info.setEucaCreateStartTime(JsonHelper.getStringFromJsonNode(new TextNode("" + System.currentTimeMillis())));
         return action;
       }
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
-      }
     },
     CHECK_SIGNALS {
       @Override
@@ -324,12 +319,6 @@ public class AWSCloudFormationWaitConditionResourceAction extends StepBasedResou
       public ResourceAction perform(ResourceAction resourceAction) throws Exception {
         return resourceAction; // nothing to do really
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudWatchAlarmResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSCloudWatchAlarmResourceAction.java
@@ -143,12 +143,6 @@ public class AWSCloudWatchAlarmResourceAction extends StepBasedResourceAction {
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -173,12 +167,6 @@ public class AWSCloudWatchAlarmResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -235,16 +223,8 @@ public class AWSCloudWatchAlarmResourceAction extends StepBasedResourceAction {
         AsyncRequests.<PutMetricAlarmType, PutMetricAlarmResponseType> sendSync(configuration, putMetricAlarmType);
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
-
-
 
   @Override
   public ResourceProperties getResourceProperties() {

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2DHCPOptionsResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2DHCPOptionsResourceAction.java
@@ -173,14 +173,7 @@ public class AWSEC2DHCPOptionsResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
-
   }
 
   private enum DeleteSteps implements Step {
@@ -204,12 +197,6 @@ public class AWSEC2DHCPOptionsResourceAction extends StepBasedResourceAction {
         AsyncRequests.<DeleteDhcpOptionsType,DeleteDhcpOptionsResponseType> sendSync(configuration, deleteDhcpOptionsType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -269,12 +256,6 @@ public class AWSEC2DHCPOptionsResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2EIPAssociationResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2EIPAssociationResourceAction.java
@@ -223,12 +223,6 @@ public class AWSEC2EIPAssociationResourceAction extends StepBasedResourceAction 
 
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -286,12 +280,6 @@ public class AWSEC2EIPAssociationResourceAction extends StepBasedResourceAction 
 
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -373,16 +361,8 @@ public class AWSEC2EIPAssociationResourceAction extends StepBasedResourceAction 
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
-
-
 
   @Override
   public ResourceProperties getResourceProperties() {
@@ -403,10 +383,6 @@ public class AWSEC2EIPAssociationResourceAction extends StepBasedResourceAction 
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2EIPAssociationResourceInfo) resourceInfo;
   }
-
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2EIPResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2EIPResourceAction.java
@@ -167,12 +167,6 @@ public class AWSEC2EIPResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -229,12 +223,6 @@ public class AWSEC2EIPResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -323,11 +311,6 @@ public class AWSEC2EIPResourceAction extends StepBasedResourceAction {
           }
         }
         return newAction;
-      }
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceResourceAction.java
@@ -392,11 +392,6 @@ public class AWSEC2InstanceResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-
-      @Override
-      public Integer getTimeout() {
-        return null;
-      }
     },
     WAIT_UNTIL_RUNNING {
       @Override
@@ -559,12 +554,6 @@ public class AWSEC2InstanceResourceAction extends StepBasedResourceAction {
       public Integer getTimeout() {
         return (int) TimeUnit.HOURS.toSeconds(12);
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -613,12 +602,6 @@ public class AWSEC2InstanceResourceAction extends StepBasedResourceAction {
       public Integer getTimeout() {
         return INSTANCE_TERMINATED_MAX_DELETE_RETRY_SECS;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -938,12 +921,6 @@ public class AWSEC2InstanceResourceAction extends StepBasedResourceAction {
       public Integer getTimeout() {
         return INSTANCE_ATTACH_VOLUME_MAX_UPDATE_RETRY_SECS;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -1160,14 +1137,8 @@ public class AWSEC2InstanceResourceAction extends StepBasedResourceAction {
       public Integer getTimeout() {
         return INSTANCE_RUNNING_MAX_UPDATE_RETRY_SECS;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
-  };
+  }
 
   private static AttributeBooleanFlatValueType convertToAttributeBooleanFlatValueType(Boolean value) {
     AttributeBooleanFlatValueType attributeBooleanFlatValueType = new AttributeBooleanFlatValueType();

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceResourceAction.java
@@ -1069,7 +1069,7 @@ public class AWSEC2InstanceResourceAction extends StepBasedResourceAction {
           } else {
             ModifyInstanceAttributeType modifyInstanceAttributeType = MessageHelper.createMessage(ModifyInstanceAttributeType.class, newAction.info.getEffectiveUserId());
             modifyInstanceAttributeType.setInstanceId(newAction.info.getPhysicalResourceId());
-            modifyInstanceAttributeType.setInstanceType(convertToAttributeValueType("m1.small"));
+            modifyInstanceAttributeType.setInstanceType(convertToAttributeValueType("t2.micro"));
             AsyncRequests.sendSync(configuration, modifyInstanceAttributeType);
           }
         }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceTypeResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceTypeResourceAction.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.actions;
+
+import com.eucalyptus.cloudformation.resources.ResourceAction;
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.standard.info.AWSEC2InstanceTypeResourceInfo;
+import com.eucalyptus.cloudformation.resources.standard.propertytypes.AWSEC2InstanceTypeProperties;
+import com.eucalyptus.cloudformation.workflow.steps.Step;
+import com.eucalyptus.cloudformation.workflow.steps.StepBasedResourceAction;
+import com.eucalyptus.cloudformation.workflow.steps.UpdateStep;
+import com.eucalyptus.cloudformation.workflow.updateinfo.UpdateType;
+import com.eucalyptus.compute.common.ComputeApi;
+import com.eucalyptus.compute.common.ModifyInstanceTypeAttributeType;
+import com.eucalyptus.util.async.AsyncProxy;
+
+
+/**
+ *
+ */
+public class AWSEC2InstanceTypeResourceAction extends StepBasedResourceAction {
+
+  private AWSEC2InstanceTypeProperties properties = new AWSEC2InstanceTypeProperties();
+  private AWSEC2InstanceTypeResourceInfo info = new AWSEC2InstanceTypeResourceInfo();
+
+  public AWSEC2InstanceTypeResourceAction() {
+    super(fromEnum(CreateSteps.class), fromEnum(DeleteSteps.class), fromUpdateEnum(UpdateNoInterruptionSteps.class), null);
+  }
+
+  @Override
+  public UpdateType getUpdateType(ResourceAction resourceAction, boolean stackTagsChanged) {
+    return UpdateType.NO_INTERRUPTION;
+  }
+
+  private enum CreateSteps implements Step {
+    CREATE_OR_UPDATE_ATTRIBUTES {
+      @Override
+      public ResourceAction perform( ResourceAction resourceAction ) {
+        final AWSEC2InstanceTypeResourceAction action = (AWSEC2InstanceTypeResourceAction) resourceAction;
+        final ComputeApi computeApi = AsyncProxy.client( ComputeApi.class, request -> {request.setEffectiveUserId(action.info.getEffectiveUserId()); return request;} );
+        final ModifyInstanceTypeAttributeType modifyInstanceType = new ModifyInstanceTypeAttributeType( );
+        modifyInstanceType.setName(action.properties.getName());
+        modifyInstanceType.setCpu(action.properties.getCpu());
+        modifyInstanceType.setDisk(action.properties.getDisk());
+        modifyInstanceType.setEnabled(action.properties.getEnabled());
+        modifyInstanceType.setMemory(action.properties.getMemory());
+        modifyInstanceType.setNetworkInterfaces(action.properties.getNetworkInterfaces());
+        computeApi.modifyInstanceType( modifyInstanceType );
+        action.info.setPhysicalResourceId(action.properties.getName());
+        action.info.setCreatedEnoughToDelete( true );
+        return action;
+      }
+    }
+  }
+
+  private enum DeleteSteps implements Step {
+    NOOP {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) {
+        return resourceAction;
+      }
+    },
+  }
+
+  private enum UpdateNoInterruptionSteps implements UpdateStep {
+    UPDATE_ATTRIBUTES {
+      @Override
+      public ResourceAction perform(
+          final ResourceAction oldResourceAction,
+          final ResourceAction newResourceAction
+      ) {
+        final AWSEC2InstanceTypeResourceAction newAction = (AWSEC2InstanceTypeResourceAction) newResourceAction;
+        final ComputeApi computeApi = AsyncProxy.client( ComputeApi.class, request -> {request.setEffectiveUserId(newAction.info.getEffectiveUserId()); return request;}  );
+        final ModifyInstanceTypeAttributeType modifyInstanceType = new ModifyInstanceTypeAttributeType( );
+        modifyInstanceType.setName(newAction.properties.getName( ));
+        modifyInstanceType.setCpu(newAction.properties.getCpu());
+        modifyInstanceType.setDisk(newAction.properties.getDisk());
+        modifyInstanceType.setEnabled(newAction.properties.getEnabled());
+        modifyInstanceType.setMemory(newAction.properties.getMemory());
+        modifyInstanceType.setNetworkInterfaces(newAction.properties.getNetworkInterfaces());
+        computeApi.modifyInstanceType( modifyInstanceType );
+        return newAction;
+      }
+    },
+  }
+
+  @Override
+  public ResourceProperties getResourceProperties() {
+    return properties;
+  }
+
+  @Override
+  public void setResourceProperties(ResourceProperties resourceProperties) {
+    properties = (AWSEC2InstanceTypeProperties) resourceProperties;
+  }
+
+  @Override
+  public ResourceInfo getResourceInfo() {
+    return info;
+  }
+
+  @Override
+  public void setResourceInfo(ResourceInfo resourceInfo) {
+    info = (AWSEC2InstanceTypeResourceInfo) resourceInfo;
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InternetGatewayResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InternetGatewayResourceAction.java
@@ -130,11 +130,6 @@ public class AWSEC2InternetGatewayResourceAction extends StepBasedResourceAction
         }
         return action;
       }
-    };
-
-    @Override
-    public Integer getTimeout( ) {
-      return null;
     }
   }
 
@@ -159,11 +154,6 @@ public class AWSEC2InternetGatewayResourceAction extends StepBasedResourceAction
         AsyncRequests.<DeleteInternetGatewayType,DeleteInternetGatewayResponseType> sendSync(configuration, deleteInternetGatewayType);
         return action;
       }
-    };
-
-    @Override
-    public Integer getTimeout( ) {
-      return null;
     }
   }
 
@@ -223,12 +213,6 @@ public class AWSEC2InternetGatewayResourceAction extends StepBasedResourceAction
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -251,9 +235,6 @@ public class AWSEC2InternetGatewayResourceAction extends StepBasedResourceAction
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2InternetGatewayResourceInfo) resourceInfo;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NatGatewayResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NatGatewayResourceAction.java
@@ -133,13 +133,6 @@ public class AWSEC2NatGatewayResourceAction extends StepBasedResourceAction {
       public Integer getTimeout() {
         return NAT_GATEWAY_AVAILABLE_MAX_CREATE_RETRY_SECS;
       }
-    };
-
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -161,12 +154,6 @@ public class AWSEC2NatGatewayResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkAclEntryResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkAclEntryResourceAction.java
@@ -142,12 +142,6 @@ public class AWSEC2NetworkAclEntryResourceAction extends StepBasedResourceAction
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -186,12 +180,6 @@ public class AWSEC2NetworkAclEntryResourceAction extends StepBasedResourceAction
         DeleteNetworkAclEntryResponseType deleteNetworkAclEntryResponseType = AsyncRequests.<DeleteNetworkAclEntryType, DeleteNetworkAclEntryResponseType> sendSync(configuration, deleteNetworkAclEntryType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -216,15 +204,8 @@ public class AWSEC2NetworkAclEntryResourceAction extends StepBasedResourceAction
         ReplaceNetworkAclEntryResponseType replaceNetworkAclEntryResponseType = AsyncRequests.<ReplaceNetworkAclEntryType, ReplaceNetworkAclEntryResponseType>sendSync(configuration, replaceNetworkAclEntryType);
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
-
 
   @Override
   public ResourceProperties getResourceProperties() {
@@ -261,9 +242,6 @@ public class AWSEC2NetworkAclEntryResourceAction extends StepBasedResourceAction
     icmpTypeCodeType.setType(icmp.getType());
     return icmpTypeCodeType;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkAclResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkAclResourceAction.java
@@ -135,12 +135,6 @@ public class AWSEC2NetworkAclResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -166,12 +160,6 @@ public class AWSEC2NetworkAclResourceAction extends StepBasedResourceAction {
         DeleteNetworkAclResponseType DeleteNetworkAclResponseType = AsyncRequests.<DeleteNetworkAclType, DeleteNetworkAclResponseType> sendSync(configuration, DeleteNetworkAclType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -231,12 +219,6 @@ public class AWSEC2NetworkAclResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -259,8 +241,6 @@ public class AWSEC2NetworkAclResourceAction extends StepBasedResourceAction {
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2NetworkAclResourceInfo) resourceInfo;
   }
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceAttachmentResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceAttachmentResourceAction.java
@@ -137,14 +137,7 @@ public class AWSEC2NetworkInterfaceAttachmentResourceAction extends StepBasedRes
         return NETWORK_INTERFACE_ATTACHMENT_MAX_CREATE_OR_UPDATE_RETRY_SECS;
       }
 
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
-
   }
 
   private static void throwNotAttachedMessage(String networkInterfaceId, String instanceId) throws RetryAfterConditionCheckFailedException {
@@ -236,12 +229,6 @@ public class AWSEC2NetworkInterfaceAttachmentResourceAction extends StepBasedRes
       public Integer getTimeout() {
         return NETWORK_INTERFACE_DETACHMENT_MAX_DELETE_OR_UPDATE_RETRY_SECS;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout( ) {
-      return null;
     }
   }
 
@@ -322,13 +309,8 @@ public class AWSEC2NetworkInterfaceAttachmentResourceAction extends StepBasedRes
           Objects.equals(oldAction.properties.getNetworkInterfaceId(), newAction.properties.getNetworkInterfaceId())
       );
     }
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
   }
+
   private static ResourceAction waitUntilDetached(AWSEC2NetworkInterfaceAttachmentResourceAction action, ServiceConfiguration configuration) throws Exception {
     DescribeNetworkInterfacesType describeNetworkInterfacesType = MessageHelper.createMessage(DescribeNetworkInterfacesType.class, action.info.getEffectiveUserId());
     describeNetworkInterfacesType.setNetworkInterfaceIdSet(action.convertNetworkInterfaceIdSet(action.properties.getNetworkInterfaceId()));

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceResourceAction.java
@@ -300,12 +300,6 @@ public class AWSEC2NetworkInterfaceResourceAction extends StepBasedResourceActio
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -338,12 +332,6 @@ public class AWSEC2NetworkInterfaceResourceAction extends StepBasedResourceActio
         return NETWORK_INTERFACE_DELETED_MAX_DELETE_RETRY_SECS;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
 
     private static boolean checkDeleted(AWSEC2NetworkInterfaceResourceAction action, ServiceConfiguration configuration) throws Exception {
       // check if network interface still exists (return otherwise)
@@ -548,12 +536,6 @@ public class AWSEC2NetworkInterfaceResourceAction extends StepBasedResourceActio
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2RouteResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2RouteResourceAction.java
@@ -146,12 +146,6 @@ public class AWSEC2RouteResourceAction extends StepBasedResourceAction {
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -192,12 +186,6 @@ public class AWSEC2RouteResourceAction extends StepBasedResourceAction {
         DeleteRouteResponseType deleteRouteResponseType = AsyncRequests.<DeleteRouteType, DeleteRouteResponseType>sendSync(configuration, deleteRouteType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -242,12 +230,6 @@ public class AWSEC2RouteResourceAction extends StepBasedResourceAction {
         ReplaceRouteResponseType replaceRouteResponseType = AsyncRequests.<ReplaceRouteType, ReplaceRouteResponseType>sendSync(configuration, replaceRouteType);
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
   @Override

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2RouteTableResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2RouteTableResourceAction.java
@@ -135,12 +135,6 @@ public class AWSEC2RouteTableResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -165,12 +159,6 @@ public class AWSEC2RouteTableResourceAction extends StepBasedResourceAction {
         DeleteRouteTableResponseType DeleteRouteTableResponseType = AsyncRequests.<DeleteRouteTableType, DeleteRouteTableResponseType> sendSync(configuration, DeleteRouteTableType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -230,12 +218,6 @@ public class AWSEC2RouteTableResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -258,9 +240,6 @@ public class AWSEC2RouteTableResourceAction extends StepBasedResourceAction {
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2RouteTableResourceInfo) resourceInfo;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SecurityGroupEgressResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SecurityGroupEgressResourceAction.java
@@ -164,12 +164,6 @@ public class AWSEC2SecurityGroupEgressResourceAction extends StepBasedResourceAc
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -224,12 +218,6 @@ public class AWSEC2SecurityGroupEgressResourceAction extends StepBasedResourceAc
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SecurityGroupIngressResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SecurityGroupIngressResourceAction.java
@@ -195,12 +195,6 @@ public class AWSEC2SecurityGroupIngressResourceAction extends StepBasedResourceA
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -276,12 +270,6 @@ public class AWSEC2SecurityGroupIngressResourceAction extends StepBasedResourceA
         RevokeSecurityGroupIngressResponseType revokeSecurityGroupIngressResponseType = AsyncRequests.<RevokeSecurityGroupIngressType, RevokeSecurityGroupIngressResponseType> sendSync(configuration, revokeSecurityGroupIngressType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SecurityGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SecurityGroupResourceAction.java
@@ -245,12 +245,6 @@ public class AWSEC2SecurityGroupResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -491,12 +485,6 @@ public class AWSEC2SecurityGroupResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -508,9 +496,6 @@ public class AWSEC2SecurityGroupResourceAction extends StepBasedResourceAction {
     ipPermissionType.setCidrIpRanges(Lists.newArrayList("0.0.0.0/0"));
     return ipPermissionType;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SubnetNetworkAclAssociationResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SubnetNetworkAclAssociationResourceAction.java
@@ -108,12 +108,6 @@ public class AWSEC2SubnetNetworkAclAssociationResourceAction extends StepBasedRe
         action.info.setAssociationId(JsonHelper.getStringFromJsonNode(new TextNode(newAssociationId)));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -137,12 +131,6 @@ public class AWSEC2SubnetNetworkAclAssociationResourceAction extends StepBasedRe
         action.replaceAssociation(configuration, action.info.getPhysicalResourceId(), defaultNetworkAclId);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SubnetResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SubnetResourceAction.java
@@ -178,12 +178,6 @@ public class AWSEC2SubnetResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -303,12 +297,6 @@ public class AWSEC2SubnetResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -331,9 +319,6 @@ public class AWSEC2SubnetResourceAction extends StepBasedResourceAction {
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2SubnetResourceInfo) resourceInfo;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SubnetRouteTableAssociationResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2SubnetRouteTableAssociationResourceAction.java
@@ -105,12 +105,6 @@ public class AWSEC2SubnetRouteTableAssociationResourceAction extends StepBasedRe
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -128,12 +122,6 @@ public class AWSEC2SubnetRouteTableAssociationResourceAction extends StepBasedRe
         action.disassociateRouteTable(configuration, action.info.getPhysicalResourceId());
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -150,13 +138,6 @@ public class AWSEC2SubnetRouteTableAssociationResourceAction extends StepBasedRe
         newAction.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(newAction.info.getPhysicalResourceId())));
         return newAction;
       }
-    },
-    ;
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VPCDHCPOptionsAssociationResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VPCDHCPOptionsAssociationResourceAction.java
@@ -117,12 +117,6 @@ public class AWSEC2VPCDHCPOptionsAssociationResourceAction extends StepBasedReso
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -160,12 +154,6 @@ public class AWSEC2VPCDHCPOptionsAssociationResourceAction extends StepBasedReso
         AsyncRequests.<AssociateDhcpOptionsType,AssociateDhcpOptionsResponseType> sendSync(configuration, associateDhcpOptionsType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -202,12 +190,6 @@ public class AWSEC2VPCDHCPOptionsAssociationResourceAction extends StepBasedReso
         AsyncRequests.<AssociateDhcpOptionsType,AssociateDhcpOptionsResponseType> sendSync(configuration, associateDhcpOptionsType);
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -230,9 +212,6 @@ public class AWSEC2VPCDHCPOptionsAssociationResourceAction extends StepBasedReso
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2VPCDHCPOptionsAssociationResourceInfo) resourceInfo;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VPCGatewayAttachmentResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VPCGatewayAttachmentResourceAction.java
@@ -126,12 +126,6 @@ public class AWSEC2VPCGatewayAttachmentResourceAction extends StepBasedResourceA
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -179,12 +173,6 @@ public class AWSEC2VPCGatewayAttachmentResourceAction extends StepBasedResourceA
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -227,16 +215,8 @@ public class AWSEC2VPCGatewayAttachmentResourceAction extends StepBasedResourceA
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
-
-
 
   @Override
   public ResourceProperties getResourceProperties() {
@@ -270,9 +250,6 @@ public class AWSEC2VPCGatewayAttachmentResourceAction extends StepBasedResourceA
 
     vpnGatewayIdSetItem.setVpnGatewayId(vpnGatewayId);
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VPCResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VPCResourceAction.java
@@ -212,12 +212,6 @@ public class AWSEC2VPCResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -242,12 +236,6 @@ public class AWSEC2VPCResourceAction extends StepBasedResourceAction {
         AsyncRequests.<DeleteVpcType,DeleteVpcResponseType> sendSync(configuration, deleteVpcType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -360,12 +348,6 @@ public class AWSEC2VPCResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -394,9 +376,6 @@ public class AWSEC2VPCResourceAction extends StepBasedResourceAction {
     attributeBooleanValueType.setValue(value);
     return attributeBooleanValueType;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VolumeAttachmentResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VolumeAttachmentResourceAction.java
@@ -188,12 +188,6 @@ public class AWSEC2VolumeAttachmentResourceAction extends StepBasedResourceActio
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -249,12 +243,6 @@ public class AWSEC2VolumeAttachmentResourceAction extends StepBasedResourceActio
         return VOLUME_DETACHMENT_MAX_DELETE_RETRY_SECS;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
 
     private static boolean notCreatedOrNoInstanceOrNoVolume(AWSEC2VolumeAttachmentResourceAction action, ServiceConfiguration configuration) throws Exception {
       if (!Boolean.TRUE.equals(action.info.getCreatedEnoughToDelete())) return true;

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VolumeResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2VolumeResourceAction.java
@@ -243,12 +243,6 @@ public class AWSEC2VolumeResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -357,12 +351,6 @@ public class AWSEC2VolumeResourceAction extends StepBasedResourceAction {
       }
     };
 
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
-
     private static boolean volumeDeleted(AWSEC2VolumeResourceAction action, ServiceConfiguration configuration) throws Exception {
       if (!Boolean.TRUE.equals(action.info.getCreatedEnoughToDelete())) return true;
       DescribeVolumesType describeVolumesType = MessageHelper.createMessage(DescribeVolumesType.class, action.info.getEffectiveUserId());
@@ -462,12 +450,6 @@ public class AWSEC2VolumeResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -490,9 +472,6 @@ public class AWSEC2VolumeResourceAction extends StepBasedResourceAction {
   public void setResourceInfo(ResourceInfo resourceInfo) {
     info = (AWSEC2VolumeResourceInfo) resourceInfo;
   }
-
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingLoadBalancerResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingLoadBalancerResourceAction.java
@@ -489,12 +489,6 @@ public class AWSElasticLoadBalancingLoadBalancerResourceAction extends StepBased
         ServiceConfiguration configuration = Topology.lookup(LoadBalancing.class);
         return describeLoadBalancerToGetAttributes(action, configuration);
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -610,12 +604,6 @@ public class AWSElasticLoadBalancingLoadBalancerResourceAction extends StepBased
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -770,11 +758,6 @@ public class AWSElasticLoadBalancingLoadBalancerResourceAction extends StepBased
         ServiceConfiguration configuration = Topology.lookup(LoadBalancing.class);
         return describeLoadBalancerToGetAttributes(newAction, configuration);
       }
-    };
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -958,12 +941,6 @@ public class AWSElasticLoadBalancingLoadBalancerResourceAction extends StepBased
             "replacing. Rename " + oldAction.properties.getLoadBalancerName() + " and update the stack again.");
         }
         return newAction;
-      }
-
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMAccessKeyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMAccessKeyResourceAction.java
@@ -127,12 +127,6 @@ public class AWSIAMAccessKeyResourceAction extends StepBasedResourceAction {
         AsyncRequests.<UpdateAccessKeyType,UpdateAccessKeyResponseType> sendSync(configuration, updateAccessKeyType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -156,12 +150,6 @@ public class AWSIAMAccessKeyResourceAction extends StepBasedResourceAction {
         AsyncRequests.<DeleteAccessKeyType,DeleteAccessKeyResponseType> sendSync(configuration, deleteAccessKeyType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -201,12 +189,6 @@ public class AWSIAMAccessKeyResourceAction extends StepBasedResourceAction {
         AsyncRequests.<UpdateAccessKeyType,UpdateAccessKeyResponseType> sendSync(configuration, updateAccessKeyType);
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -222,12 +204,6 @@ public class AWSIAMAccessKeyResourceAction extends StepBasedResourceAction {
           throw new ValidationErrorException("AccessKey Serial cannot be decreased");
         }
         return newAction;
-      }
-
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMGroupResourceAction.java
@@ -165,11 +165,6 @@ public class AWSIAMGroupResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -200,12 +195,6 @@ public class AWSIAMGroupResourceAction extends StepBasedResourceAction {
         AsyncRequests.<DeleteGroupType,DeleteGroupResponseType> sendSync(configuration, deleteGroupType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -339,13 +328,6 @@ public class AWSIAMGroupResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -360,16 +342,8 @@ public class AWSIAMGroupResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
-      }
     }
   }
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMInstanceProfileResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMInstanceProfileResourceAction.java
@@ -125,12 +125,6 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -150,12 +144,6 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
         AsyncRequests.<DeleteInstanceProfileType,DeleteInstanceProfileResponseType> sendSync(configuration, deleteInstanceProfileType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -223,16 +211,8 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
         }
         return newAction;
       }
-
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMManagedPolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMManagedPolicyResourceAction.java
@@ -184,12 +184,6 @@ public class AWSIAMManagedPolicyResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -266,12 +260,6 @@ public class AWSIAMManagedPolicyResourceAction extends StepBasedResourceAction {
 
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -438,12 +426,6 @@ public class AWSIAMManagedPolicyResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMPolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMPolicyResourceAction.java
@@ -164,12 +164,6 @@ public class AWSIAMPolicyResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -212,12 +206,6 @@ public class AWSIAMPolicyResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -331,16 +319,8 @@ public class AWSIAMPolicyResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
-
-
 }
 
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMRoleResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMRoleResourceAction.java
@@ -166,12 +166,6 @@ public class AWSIAMRoleResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -200,12 +194,6 @@ public class AWSIAMRoleResourceAction extends StepBasedResourceAction {
         AsyncRequests.<DeleteRoleType,DeleteRoleResponseType> sendSync(configuration, deleteRoleType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -339,12 +327,6 @@ public class AWSIAMRoleResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -358,12 +340,6 @@ public class AWSIAMRoleResourceAction extends StepBasedResourceAction {
           throw new ValidationErrorException("CloudFormation cannot update a stack when a custom-named resource requires replacing. Rename "+oldAction.properties.getRoleName()+" and update the stack again.");
         }
         return newAction;
-      }
-
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMUserResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMUserResourceAction.java
@@ -217,12 +217,6 @@ public class AWSIAMUserResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -286,12 +280,6 @@ public class AWSIAMUserResourceAction extends StepBasedResourceAction {
         AsyncRequests.<DeleteUserType,DeleteUserResponseType> sendSync(configuration, deleteUserType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -503,13 +491,6 @@ public class AWSIAMUserResourceAction extends StepBasedResourceAction {
         newAction.info.setArn(JsonHelper.getStringFromJsonNode(new TextNode(user.getArn())));
         return newAction;
       }
-    };
-
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -523,12 +504,6 @@ public class AWSIAMUserResourceAction extends StepBasedResourceAction {
           throw new ValidationErrorException("CloudFormation cannot update a stack when a custom-named resource requires replacing. Rename "+oldAction.properties.getUserName()+" and update the stack again.");
         }
         return newAction;
-      }
-
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMUserToGroupAdditionResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMUserToGroupAdditionResourceAction.java
@@ -111,12 +111,6 @@ public class AWSIAMUserToGroupAdditionResourceAction extends StepBasedResourceAc
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -130,12 +124,6 @@ public class AWSIAMUserToGroupAdditionResourceAction extends StepBasedResourceAc
         IAMHelper.removeUsersFromGroup(configuration, action.properties.getUsers(), action.properties.getGroupName(), action.info.getEffectiveUserId());
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -205,12 +193,6 @@ public class AWSIAMUserToGroupAdditionResourceAction extends StepBasedResourceAc
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSS3BucketPolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSS3BucketPolicyResourceAction.java
@@ -91,11 +91,6 @@ public class AWSS3BucketPolicyResourceAction extends StepBasedResourceAction {
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;
       }
-    };
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -117,12 +112,6 @@ public class AWSS3BucketPolicyResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -158,11 +147,6 @@ public class AWSS3BucketPolicyResourceAction extends StepBasedResourceAction {
           s3c.setBucketPolicy(newAction.properties.getBucket(), newAction.properties.getPolicyDocument().toString());
         }
         return newAction;
-      }
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSS3BucketResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSS3BucketResourceAction.java
@@ -225,12 +225,6 @@ public class AWSS3BucketResourceAction extends StepBasedResourceAction {
         return action;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
   }
 
   private enum DeleteSteps implements Step {
@@ -251,12 +245,6 @@ public class AWSS3BucketResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -501,12 +489,6 @@ public class AWSS3BucketResourceAction extends StepBasedResourceAction {
           newAction.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(newAction.info.getPhysicalResourceId())));
           return newAction;
         }
-      }
-
-      @Nullable
-      @Override
-      public Integer getTimeout() {
-        return null;
       }
     }
   }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSSQSQueuePolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSSQSQueuePolicyResourceAction.java
@@ -104,12 +104,6 @@ public class AWSSQSQueuePolicyResourceAction extends StepBasedResourceAction {
         return action;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
   }
 
   private enum DeleteSteps implements Step {
@@ -125,12 +119,6 @@ public class AWSSQSQueuePolicyResourceAction extends StepBasedResourceAction {
         }
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -207,12 +195,6 @@ public class AWSSQSQueuePolicyResourceAction extends StepBasedResourceAction {
         }
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSSQSQueueResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSSQSQueueResourceAction.java
@@ -133,12 +133,6 @@ public class AWSSQSQueueResourceAction extends StepBasedResourceAction {
         return action;
       }
     };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
-    }
   }
 
   private enum DeleteSteps implements Step {
@@ -153,12 +147,6 @@ public class AWSSQSQueueResourceAction extends StepBasedResourceAction {
         AsyncRequests.sendSync(configuration, deleteQueueType);
         return action;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 
@@ -205,12 +193,6 @@ public class AWSSQSQueueResourceAction extends StepBasedResourceAction {
         AsyncRequests.sendSync(configuration, setQueueAttributesType);
         return newAction;
       }
-    };
-
-    @Nullable
-    @Override
-    public Integer getTimeout() {
-      return null;
     }
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSEC2InstanceTypeResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSEC2InstanceTypeResourceInfo.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.info;
+
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.google.common.base.MoreObjects;
+
+public class AWSEC2InstanceTypeResourceInfo extends ResourceInfo {
+
+  public AWSEC2InstanceTypeResourceInfo( ) {
+    setType( "AWS::EC2::InstanceType" );
+  }
+
+  @Override
+  public String toString( ) {
+    return MoreObjects.toStringHelper( this )
+        .toString( );
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2InstanceTypeProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2InstanceTypeProperties.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.eucalyptus.cloudformation.resources.annotations.Required;
+import com.google.common.base.MoreObjects;
+
+public class AWSEC2InstanceTypeProperties implements ResourceProperties {
+
+  @Property
+  @Required
+  private String name;
+
+  @Property
+  private Integer cpu;
+
+  @Property
+  private Integer disk;
+
+  @Property
+  private Integer memory;
+
+  @Property
+  private Integer networkInterfaces;
+
+  @Property
+  private Boolean enabled;
+
+  public String getName( ) {
+    return name;
+  }
+
+  public void setName( final String name ) {
+    this.name = name;
+  }
+
+  public Integer getCpu( ) {
+    return cpu;
+  }
+
+  public void setCpu( final Integer cpu ) {
+    this.cpu = cpu;
+  }
+
+  public Integer getDisk( ) {
+    return disk;
+  }
+
+  public void setDisk( final Integer disk ) {
+    this.disk = disk;
+  }
+
+  public Integer getMemory( ) {
+    return memory;
+  }
+
+  public void setMemory( final Integer memory ) {
+    this.memory = memory;
+  }
+
+  public Integer getNetworkInterfaces( ) {
+    return networkInterfaces;
+  }
+
+  public void setNetworkInterfaces( final Integer networkInterfaces ) {
+    this.networkInterfaces = networkInterfaces;
+  }
+
+  public Boolean getEnabled( ) {
+    return enabled;
+  }
+
+  public void setEnabled( final Boolean enabled ) {
+    this.enabled = enabled;
+  }
+
+  @Override
+  public String toString( ) {
+    return MoreObjects.toStringHelper( this )
+        .add( "name", name )
+        .add( "cpu", cpu )
+        .add( "disk", disk )
+        .add( "memory", memory )
+        .add( "networkInterfaces", networkInterfaces )
+        .add( "enabled", enabled )
+        .toString( );
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/workflow/steps/Step.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/workflow/steps/Step.java
@@ -48,5 +48,7 @@ public interface Step extends Nameable{
    * @see #MAX_TIMEOUT
    */
   @Nullable
-  Integer getTimeout( );
+  default Integer getTimeout( ) {
+    return null;
+  }
 }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/workflow/steps/UpdateStep.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/workflow/steps/UpdateStep.java
@@ -48,5 +48,7 @@ public interface UpdateStep extends Nameable{
    * @see #MAX_TIMEOUT
    */
   @Nullable
-  Integer getTimeout();
+  default Integer getTimeout( ){
+    return null;
+  };
 }

--- a/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/ResourceState.java
+++ b/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/ResourceState.java
@@ -411,7 +411,7 @@ public class ResourceState {
     
     static class ZeroTypeAvailability extends VmTypeAvailability {
       ZeroTypeAvailability( ) {
-        super( VmType.create( "ZERO", -1, -1, -1, -1 ), 0, 0 );
+        super( VmType.create( "ZERO", -1, -1, -1, -1, false ), 0, 0 );
       }
       
       @Override

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/cloud/run/VerifyMetadata.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/cloud/run/VerifyMetadata.java
@@ -143,7 +143,7 @@ public class VerifyMetadata {
     public boolean apply( Allocation allocInfo ) throws MetadataException {
       String instanceType = allocInfo.getRequest( ).getInstanceType( );
       VmType vmType = VmTypes.lookup( instanceType );
-      if ( !RestrictedTypes.filterPrivileged( ).apply( vmType ) ) {
+      if ( !vmType.getEnabled() || !RestrictedTypes.filterPrivileged( ).apply( vmType ) ) {
         throw new IllegalMetadataAccessException( "Not authorized to allocate vm type " + instanceType + " for " + allocInfo.getOwnerFullName() );
       }
       allocInfo.setVmType( vmType );

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/cluster/ClusterEndpoint.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/cluster/ClusterEndpoint.java
@@ -330,7 +330,7 @@ public class ClusterEndpoint {
                                                                                                                       + cluster.getConfiguration( ).getFullName( ) ) );
                                                                                    info.add( new ClusterInfoType( String.format( INFO_FSTRING, "vm types" ),
                                                                                                                   HEADER_STRING ) );
-                                                                                   for ( VmType v : VmTypes.list( ) ) {
+                                                                                   for ( VmType v : VmTypes.listEnabled( ) ) {
                                                                                      VmTypeAvailability va = cluster.getNodeState( ).getAvailability( v );
                                                                                      info.add( s( v.getName( ),
                                                                                                   String.format( STATE_FSTRING, va.getAvailable( ),

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstanceAvailabilityEventListener.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstanceAvailabilityEventListener.java
@@ -90,7 +90,7 @@ public class VmInstanceAvailabilityEventListener implements EventListener<ClockT
 
       final ArrayListMultimap<ResourceType,Availability> availabilityByType = ArrayListMultimap.create( );
       final Map<ResourceType,AvailabilityAccumulator> availabilities = Maps.newEnumMap( ResourceType.class );
-      final Iterable<VmType> vmTypes = Lists.newArrayList( VmTypes.list( ) );
+      final Iterable<VmType> vmTypes = Lists.newArrayList( VmTypes.listEnabled( ) );
       for ( final Cluster cluster : Clusters.list( ) ) {
         availabilities.put( Core, new AvailabilityAccumulator( VmType.SizeProperties.Cpu ) );
         availabilities.put( Disk, new AvailabilityAccumulator( VmType.SizeProperties.Disk ) );

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypes.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypes.java
@@ -43,7 +43,6 @@ import static com.eucalyptus.upgrade.Upgrades.Version.v4_3_0;
 
 import java.util.NavigableSet;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -78,7 +77,6 @@ import com.eucalyptus.compute.common.internal.images.BlockStorageImageInfo;
 import com.eucalyptus.compute.common.internal.images.BootableImageInfo;
 import com.eucalyptus.entities.TransactionResource;
 import com.eucalyptus.images.ImageManager;
-import com.eucalyptus.images.Images;
 import com.eucalyptus.compute.common.internal.images.MachineImageInfo;
 import com.eucalyptus.upgrade.Upgrades.EntityUpgrade;
 import com.eucalyptus.util.Classes;
@@ -102,12 +100,12 @@ public class VmTypes {
   private static Logger LOG = Logger.getLogger( VmTypes.class );
 
   static {
-    VmTypesSupplier.init( VmTypes::list );
+    VmTypesSupplier.init( VmTypes::listEnabled );
   }
 
   @ConfigurableField( description = "Default type used when no instance type is specified for run instances.",
-                      initial = "m1.small" )
-  public static String         DEFAULT_TYPE_NAME        = "m1.small";
+                      initial = "t2.micro" )
+  public static String         DEFAULT_TYPE_NAME        = "t2.micro";
 
   @ConfigurableField( description = "Format first ephemeral disk by default with ext3", initial = "true",
       changeListener = PropertyChangeListeners.IsBoolean.class)
@@ -117,15 +115,11 @@ public class VmTypes {
       initial = "false", changeListener = PropertyChangeListeners.IsBoolean.class)
   public static Boolean        FORMAT_SWAP = false;
 
-  @Deprecated
-  //GRZE: this and all its references must be removed to complete the vm type support
-  protected static final Long  SWAP_SIZE_BYTES          = 512 * 1024l * 1024l; // swap is hardcoded at 512MB for now
-  @Deprecated
-  //GRZE: this and all its references must be removed to complete the vm type support
-  private static final long    MIN_EPHEMERAL_SIZE_BYTES = 61440;              // the smallest ext{2|3|4} partition possible
-  private static final Integer GB                       = 1024;
-  private static final Integer ROOTFS                   = 10;
-  
+  private static final Long    SWAP_SIZE_BYTES          = 512 * 1024L * 1024L; // swap is hardcoded at 512MB for now
+  private static final long    MIN_EPHEMERAL_SIZE_BYTES = 61440;               // the smallest ext{2|3|4} partition possible
+  private static final Function<PredefinedTypes,Boolean> DEFAULT_ENABLE =
+      pt -> pt.getName( ).startsWith( "t2." ) || pt.getName( ).startsWith( "m5." );
+
   private enum ClusterAvailability implements Predicate<ServiceConfiguration> {
     INSTANCE;
 
@@ -153,19 +147,19 @@ public class VmTypes {
   }
 
   public static boolean isUnorderedType( VmType vmType ) {
-    return Iterables.any( VmTypes.list( ), vmType.orderedPredicate( ) );
+    return Iterables.any( VmTypes.listEnabled( ), vmType.orderedPredicate( ) );
   }
   
   public static VmType update( VmType newVmType ) throws NoSuchMetadataException {
     VmType vmType = VmTypes.lookup( newVmType.getName( ) );
-    VmType resultType = vmType;
+    VmType resultType;
     if ( vmType != null ) {
       Registry.INSTANCE.replace( newVmType );
       //return canonical map reference of vm type
-      resultType = Registry.INSTANCE.get( newVmType.getDisplayName( ) );
+      resultType = Registry.get( newVmType.getDisplayName( ) );
     } else {
       Registry.INSTANCE.putIfAbsent( newVmType );
-      resultType = Registry.INSTANCE.get( newVmType.getDisplayName( ) );
+      resultType = Registry.get( newVmType.getDisplayName( ) );
     }
     ClusterAvailability.reset( );
     return resultType;
@@ -178,7 +172,11 @@ public class VmTypes {
   public static synchronized NavigableSet<VmType> list( ) {
     return Registry.list( );
   }
-  
+
+  public static synchronized NavigableSet<VmType> listEnabled( ) {
+    return Registry.listEnabled( );
+  }
+
   public static String defaultTypeName( ) {
     return DEFAULT_TYPE_NAME;
   }
@@ -202,7 +200,8 @@ public class VmTypes {
           LOG.debug( "Instance type not found for " + input );
         }
         PredefinedTypes t = PredefinedTypes.valueOf( input.toUpperCase( ).replace( ".", "" ) );
-        VmType vmType = VmType.create( input, t.getCpu( ), t.getDisk( ), t.getMemory( ), t.getEthernetInterfaceLimit( ) );
+        VmType vmType = VmType.create( input, t.getCpu( ), t.getDisk( ), t.getMemory( ),
+                                       t.getEthernetInterfaceLimit( ), DEFAULT_ENABLE.apply( t ) );
         vmType = Entities.persist( vmType );
         Iterators.size( vmType.getEphemeralDisks().iterator() ); // Ensure materialized
         return vmType;
@@ -258,7 +257,7 @@ public class VmTypes {
     
     @Override
     public V remove( Object object ) {
-      V ret = null;
+      V ret;
       if ( ( ret = this.delegate( ).remove( object ) ) != null ) {
         this.removeFunction.apply( ( V ) object );
       }
@@ -338,7 +337,8 @@ public class VmTypes {
                     preDefVmType.getCpu( ),
                     preDefVmType.getDisk( ),
                     preDefVmType.getMemory( ),
-                    preDefVmType.getEthernetInterfaceLimit( )
+                    preDefVmType.getEthernetInterfaceLimit( ),
+                    DEFAULT_ENABLE.apply( preDefVmType )
                 ) );
             }
           }
@@ -371,157 +371,181 @@ public class VmTypes {
       INSTANCE.initialize( );
       return Sets.newTreeSet( INSTANCE.vmTypeMap.values( ) );
     }
-    
-  }
-  
-  enum VirtualDevice {
-    ephemeral0,
-    ephemeral1,
-    ephemeral2,
-    ephemeral3;
-    
-    public EphemeralDisk create( String deviceName, Integer size ) {
-      return EphemeralDisk.create( this.name( ), deviceName, size, EphemeralDisk.Format.ext3 );
-    }
-    
-    public EphemeralDisk create( String deviceName, Integer size, EphemeralDisk.Format format ) {
-      return EphemeralDisk.create( this.name( ), deviceName, size, format );
-    }
-    
-    private static EphemeralDisk create( Integer ephemeralIndex, String deviceName, Integer size, EphemeralDisk.Format format ) {
-      return EphemeralDisk.create( "ephemeral" + ephemeralIndex, deviceName, size, format );
-    }
-    
-  }
 
-  enum Attribute {
-    ssd,
-    gpu,
-    ebsonly
+    public static NavigableSet<VmType> listEnabled( ) {
+      INSTANCE.initialize( );
+      return Sets.newTreeSet( Iterables.filter( INSTANCE.vmTypeMap.values( ), VmType::getEnabled ) );
+    }
   }
   
   /**
    * <table>
    * <tr>
-   * <th>Type</th>
    * <th>Name</th>
-   * <th>EC2 Compute Units (ECU)</th>
    * <th>Virtual Cores</th>
-   * <th>Memory</th>
-   * <th>Instance Store Volumes</th>
-   * <th>Platform</th>
-   * <th>I/O</th>
-   * <th>Available for Spot Instance</th>
+   * <th>Instance Store Disk (GiB)</th>
+   * <th>Memory (MiB)</th>
+   * <th>Network Interface Count</th>
    * </tr>
    * </table>
-   * 
-   * @author chris grzegorczyk <grze@eucalyptus.com>
    */
-  enum PredefinedTypes {
-    T1MICRO( "t1.micro",
-            1, ROOTFS / 2, GB / 4, 2,
-            Attribute.ebsonly ),
-    M1SMALL( "m1.small",
-            1, ROOTFS / 2, GB / 4, 2,
-            VirtualDevice.ephemeral0.create( "/dev/sda2", 10, EphemeralDisk.Format.ext3 ),
-            VirtualDevice.ephemeral1.create( "/dev/sda3", 1, EphemeralDisk.Format.swap ) ),
-    M1MEDIUM( "m1.medium",
-             1, ROOTFS, GB / 2, 2,
-             VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ) ),
-    C1MEDIUM( "c1.medium",
-             2, ROOTFS, GB / 2, 2,
-             VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ) ),
-    M1LARGE( "m1.large",
-            2, ROOTFS, GB / 2, 3,
-            VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-            VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ) ),
-    M1XLARGE( "m1.xlarge",
-             2, ROOTFS, GB, 4,
-             VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-             VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ),
-             VirtualDevice.ephemeral2.create( "/dev/sdd", 20, EphemeralDisk.Format.ext3 ),
-             VirtualDevice.ephemeral3.create( "/dev/sde", 20, EphemeralDisk.Format.ext3 ) ),
-    M2XLARGE( "m2.xlarge",
-             2, ROOTFS, 2 * GB, 4,
-             VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ) ),
-    C1XLARGE( "c1.xlarge",
-             2, ROOTFS, 2 * GB, 4,
-             VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-             VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ),
-             VirtualDevice.ephemeral2.create( "/dev/sdd", 20, EphemeralDisk.Format.ext3 ),
-             VirtualDevice.ephemeral3.create( "/dev/sde", 20, EphemeralDisk.Format.ext3 ) ),
-    M3XLARGE( "m3.xlarge",
-             4, ROOTFS + ROOTFS / 2, 2 * GB, 4,
-             Attribute.ebsonly ),
-    M22XLARGE( "m2.2xlarge",
-              2, 3 * ROOTFS, 4 * GB, 4,
-              VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ) ),
-    M32XLARGE( "m3.2xlarge",
-              4, 3 * ROOTFS, 4 * GB, 4,
-              Attribute.ebsonly ),
-    CC14XLARGE( "cc1.4xlarge",
-               8, 6 * ROOTFS, 3 * GB, 4,
-               VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ) ),
-    M24XLARGE( "m2.4xlarge",
-              8, 6 * ROOTFS, 4 * GB, 8,
-              VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-              VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ) ),
-    HI14XLARGE( "hi1.4xlarge",
-               8, 12 * ROOTFS, 6 * GB, 8,
-               Attribute.ssd,
-               VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ) ),
-    CC28XLARGE( "cc2.8xlarge",
-               16, 12 * ROOTFS, 6 * GB, 8,
-               VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral2.create( "/dev/sdd", 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral3.create( "/dev/sde", 20, EphemeralDisk.Format.ext3 ) ),
-    CG14XLARGE( "cg1.4xlarge",
-               16, 20 * ROOTFS, 12 * GB, 8,
-               Attribute.gpu,
-               VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ) ),
-    CR18XLARGE( "cr1.8xlarge",
-               16, 24 * ROOTFS, 16 * GB, 8,
-               Attribute.ssd,
-               VirtualDevice.ephemeral0.create( Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ),
-               VirtualDevice.ephemeral1.create( "/dev/sdc", 20, EphemeralDisk.Format.ext3 ) ),
-    HS18XLARGE( "hs1.8xlarge",
-               48, 24 * 100 * ROOTFS, 117 * GB, 8 ) {
-      {
-        for ( int i = 0; i < 24; i++ ) {
-          this.getEphemeralDisks( ).add( VirtualDevice.create( i, Images.DEFAULT_EPHEMERAL_DEVICE, 20, EphemeralDisk.Format.ext3 ) );
-        }
-      }
-    };
+  protected enum PredefinedTypes {
+    C1MEDIUM("c1.medium", 2, 350, 1741, 2),
+    C1XLARGE("c1.xlarge", 8, 1680, 7168, 4),
+    C32XLARGE("c3.2xlarge", 8, 160, 15360, 4),
+    C34XLARGE("c3.4xlarge", 16, 320, 30720, 8),
+    C38XLARGE("c3.8xlarge", 32, 640, 61440, 8),
+    C3LARGE("c3.large", 2, 32, 3840, 3),
+    C3XLARGE("c3.xlarge", 4, 80, 7680, 4),
+    C42XLARGE("c4.2xlarge", 8, 20, 15360, 4),
+    C44XLARGE("c4.4xlarge", 16, 20, 30720, 8),
+    C48XLARGE("c4.8xlarge", 36, 40, 61440, 8),
+    C4LARGE("c4.large", 2, 10, 3840, 3),
+    C4XLARGE("c4.xlarge", 4, 15, 7680, 4),
+    C518XLARGE("c5.18xlarge", 72, 80, 147456, 15),
+    C52XLARGE("c5.2xlarge", 8, 20, 16384, 4),
+    C54XLARGE("c5.4xlarge", 16, 20, 32768, 8),
+    C59XLARGE("c5.9xlarge", 36, 40, 73728, 8),
+    C5D18XLARGE("c5d.18xlarge", 72, 1800, 147456, 15),
+    C5D2XLARGE("c5d.2xlarge", 8, 200, 16384, 4),
+    C5D4XLARGE("c5d.4xlarge", 16, 400, 32768, 8),
+    C5D9XLARGE("c5d.9xlarge", 36, 900, 73728, 8),
+    C5DLARGE("c5d.large", 2, 50, 4096, 3),
+    C5DXLARGE("c5d.xlarge", 4, 100, 8192, 4),
+    C5LARGE("c5.large", 2, 10, 4096, 3),
+    C5XLARGE("c5.xlarge", 4, 15, 8192, 4),
+    CC28XLARGE("cc2.8xlarge", 32, 3360, 61952, 8),
+    CG14XLARGE("cg1.4xlarge", 16, 200, 12288, 8),
+    CR18XLARGE("cr1.8xlarge", 32, 240, 249856, 8),
+    D22XLARGE("d2.2xlarge", 8, 12000, 62464, 4),
+    D24XLARGE("d2.4xlarge", 16, 24000, 124928, 8),
+    D28XLARGE("d2.8xlarge", 36, 48000, 249856, 8),
+    D2XLARGE("d2.xlarge", 4, 6000, 31232, 4),
+    F116XLARGE("f1.16xlarge", 64, 3760, 999424, 8),
+    F12XLARGE("f1.2xlarge", 8, 470, 124928, 4),
+    G22XLARGE("g2.2xlarge", 8, 60, 15360, 4),
+    G28XLARGE("g2.8xlarge", 32, 240, 61440, 8),
+    G316XLARGE("g3.16xlarge", 64, 160, 499712, 15),
+    G34XLARGE("g3.4xlarge", 16, 40, 124928, 8),
+    G38XLARGE("g3.8xlarge", 32, 80, 249856, 8),
+    H116XLARGE("h1.16xlarge", 64, 16000, 262144, 15),
+    H12XLARGE("h1.2xlarge", 8, 2000, 32768, 4),
+    H14XLARGE("h1.4xlarge", 16, 4000, 65536, 8),
+    H18XLARGE("h1.8xlarge", 32, 8000, 131072, 8),
+    HI14XLARGE("hi1.4xlarge", 48, 24000, 119808, 8),
+    HS18XLARGE("hs1.8xlarge", 16, 48000, 119808, 8),
+    I22XLARGE("i2.2xlarge", 8, 1600, 62464, 4),
+    I24XLARGE("i2.4xlarge", 16, 3200, 124928, 8),
+    I28XLARGE("i2.8xlarge", 32, 6400, 249856, 8),
+    I2XLARGE("i2.xlarge", 4, 800, 31232, 4),
+    I316XLARGE("i3.16xlarge", 64, 15200, 499712, 15),
+    I32XLARGE("i3.2xlarge", 8, 1900, 62464, 4),
+    I34XLARGE("i3.4xlarge", 16, 3800, 124928, 8),
+    I38XLARGE("i3.8xlarge", 32, 7600, 249856, 8),
+    I3LARGE("i3.large", 2, 475, 15616, 3),
+    I3XLARGE("i3.xlarge", 4, 950, 31232, 4),
+    M1LARGE("m1.large", 2, 840, 7680, 3),
+    M1MEDIUM("m1.medium", 1, 410, 3840, 2),
+    M1SMALL("m1.small", 1, 160, 1741, 2),
+    M1XLARGE("m1.xlarge", 4, 1680, 15360, 4),
+    M22XLARGE("m2.2xlarge", 4, 850, 35021, 4),
+    M24XLARGE("m2.4xlarge", 8, 1680, 70042, 8),
+    M2XLARGE("m2.xlarge", 2, 420, 17510, 4),
+    M32XLARGE("m3.2xlarge", 8, 160, 30720, 4),
+    M3LARGE("m3.large", 2, 32, 7680, 3),
+    M3MEDIUM("m3.medium", 1, 4, 3840, 2),
+    M3XLARGE("m3.xlarge", 4, 80, 15360, 4),
+    M410XLARGE("m4.10xlarge", 40, 40, 163840, 8),
+    M416XLARGE("m4.16xlarge", 64, 60, 262144, 8),
+    M42XLARGE("m4.2xlarge", 8, 20, 32768, 4),
+    M44XLARGE("m4.4xlarge", 16, 20, 65536, 8),
+    M4LARGE("m4.large", 2, 10, 8192, 2),
+    M4XLARGE("m4.xlarge", 4, 15, 16384, 4),
+    M512XLARGE("m5.12xlarge", 48, 50, 196608, 8),
+    M524XLARGE("m5.24xlarge", 96, 100, 393216, 15),
+    M52XLARGE("m5.2xlarge", 8, 20, 32768, 4),
+    M54XLARGE("m5.4xlarge", 16, 20, 65536, 8),
+    M5D12XLARGE("m5d.12xlarge", 48, 1800, 196608, 8),
+    M5D24XLARGE("m5d.24xlarge", 96, 3600, 393216, 15),
+    M5D2XLARGE("m5d.2xlarge", 8, 300, 32768, 4),
+    M5D4XLARGE("m5d.4xlarge", 16, 600, 65536, 8),
+    M5DLARGE("m5d.large", 2, 75, 8192, 3),
+    M5DXLARGE("m5d.xlarge", 4, 150, 16384, 4),
+    M5LARGE("m5.large", 2, 10, 8192, 3),
+    M5XLARGE("m5.xlarge", 4, 15, 16384, 4),
+    P216XLARGE("p2.16xlarge", 64, 60, 749568, 8),
+    P28XLARGE("p2.8xlarge", 32, 40, 499712, 8),
+    P2XLARGE("p2.xlarge", 4, 20, 62464, 4),
+    P316XLARGE("p3.16xlarge", 64, 80, 499712, 8),
+    P32XLARGE("p3.2xlarge", 8, 20, 62464, 4),
+    P38XLARGE("p3.8xlarge", 32, 40, 249856, 8),
+    R32XLARGE("r3.2xlarge", 8, 160, 62464, 4),
+    R34XLARGE("r3.4xlarge", 16, 320, 124928, 8),
+    R38XLARGE("r3.8xlarge", 32, 640, 249856, 8),
+    R3LARGE("r3.large", 2, 32, 15616, 3),
+    R3XLARGE("r3.xlarge", 4, 80, 31232, 4),
+    R416XLARGE("r4.16xlarge", 64, 60, 499712, 15),
+    R42XLARGE("r4.2xlarge", 8, 20, 62464, 4),
+    R44XLARGE("r4.4xlarge", 16, 20, 124928, 8),
+    R48XLARGE("r4.8xlarge", 32, 40, 249856, 8),
+    R4LARGE("r4.large", 2, 10, 15616, 3),
+    R4XLARGE("r4.xlarge", 4, 15, 31232, 4),
+    R512XLARGE("r5.12xlarge", 48, 50, 393216, 8),
+    R524XLARGE("r5.24xlarge", 96, 100, 786432, 15),
+    R52XLARGE("r5.2xlarge", 8, 20, 65536, 4),
+    R54XLARGE("r5.4xlarge", 16, 20, 131072, 8),
+    R5D12XLARGE("r5d.12xlarge", 48, 1800, 393216, 8),
+    R5D24XLARGE("r5d.24xlarge", 96, 3600, 786432, 15),
+    R5D2XLARGE("r5d.2xlarge", 8, 300, 65536, 4),
+    R5D4XLARGE("r5d.4xlarge", 16, 600, 131072, 8),
+    R5DLARGE("r5d.large", 2, 75, 16384, 3),
+    R5DXLARGE("r5d.xlarge", 4, 150, 32768, 4),
+    R5LARGE("r5.large", 2, 10, 16384, 3),
+    R5XLARGE("r5.xlarge", 4, 15, 32768, 4),
+    T1MICRO("t1.micro", 1, 5, 628, 2),
+    T22XLARGE("t2.2xlarge", 8, 20, 32768, 3),
+    T2LARGE("t2.large", 2, 15, 8192, 3),
+    T2MEDIUM("t2.medium", 2, 10, 4096, 3),
+    T2MICRO("t2.micro", 1, 10, 1024, 2),
+    T2NANO("t2.nano", 1, 5, 512, 2),
+    T2SMALL("t2.small", 1, 10, 2048, 2),
+    T2XLARGE("t2.xlarge", 4, 15, 16384, 3),
+    T32XLARGE("t3.2xlarge", 8, 20, 32768, 4),
+    T3LARGE("t3.large", 2, 15, 8192, 3),
+    T3MEDIUM("t3.medium", 2, 10, 4096, 3),
+    T3MICRO("t3.micro", 1, 10, 1024, 2),
+    T3NANO("t3.nano", 1, 5, 512, 2),
+    T3SMALL("t3.small", 1, 10, 2048, 2),
+    T3XLARGE("t3.xlarge", 4, 15, 16384, 4),
+    X116XLARGE("x1.16xlarge", 64, 1920, 999424, 8),
+    X132XLARGE("x1.32xlarge", 128, 3840, 1998848, 8),
+    X1E16XLARGE("x1e.16xlarge", 64, 1920, 1998848, 8),
+    X1E2XLARGE("x1e.2xlarge", 8, 240, 249856, 4),
+    X1E32XLARGE("x1e.32xlarge", 128, 3840, 3997696, 8),
+    X1E4XLARGE("x1e.4xlarge", 16, 480, 499712, 4),
+    X1E8XLARGE("x1e.8xlarge", 32, 960, 999424, 4),
+    X1EXLARGE("x1e.xlarge", 4, 120, 124928, 3),
+    Z1D12XLARGE("z1d.12xlarge", 48, 1800, 393216, 15),
+    Z1D2XLARGE("z1d.2xlarge", 8, 300, 65536, 4),
+    Z1D3XLARGE("z1d.3xlarge", 12, 450, 98304, 8),
+    Z1D6XLARGE("z1d.6xlarge", 24, 900, 196608, 8),
+    Z1DLARGE("z1d.large", 2, 75, 16384, 3),
+    Z1DXLARGE("z1d.xlarge", 4, 150, 32768, 4),
+    ;
     private final String             name;
     private final Integer            cpu;
     private final Integer            disk;
     private final Integer            memory;
-    private final Boolean            ebsOnly;
     private final Integer            ethernetInterfaceLimit;
-    private final Set<EphemeralDisk> ephemeralDisks = Sets.newHashSet( );
-    
-    private PredefinedTypes( String name, Integer cpu, Integer disk, Integer memory, Integer ethernetInterfaceLimit, EphemeralDisk... disks ) {
+
+    PredefinedTypes( String name, Integer cpu, Integer disk, Integer memory, Integer ethernetInterfaceLimit ) {
       this.name = name;
       this.cpu = cpu;
       this.disk = disk;
       this.memory = memory;
       this.ethernetInterfaceLimit = ethernetInterfaceLimit;
-      this.ebsOnly = Boolean.FALSE;
     }
-    
-    private PredefinedTypes( String name, Integer cpu, Integer disk, Integer memory, Integer ethernetInterfaceLimit, Attribute attribute, EphemeralDisk... disks ) {
-      this.name = name;
-      this.cpu = cpu;
-      this.disk = disk;
-      this.memory = memory;
-      this.ethernetInterfaceLimit = ethernetInterfaceLimit;
-      this.ebsOnly = Attribute.ebsonly.equals( attribute );
-    }
-    
+
     public String getName( ) {
       return this.name;
     }
@@ -538,29 +562,21 @@ public class VmTypes {
       return this.memory;
     }
     
-    public Boolean getEbsOnly( ) {
-      return this.ebsOnly;
-    }
-    
     public Integer getEthernetInterfaceLimit( ) {
       return this.ethernetInterfaceLimit;
     }
-    
-    public Set<EphemeralDisk> getEphemeralDisks( ) {
-      return this.ephemeralDisks;
-    }
-    
+
   }
   
   public static VmTypeInfo asVmTypeInfo( VmType vmType, BootableImageInfo img ) throws MetadataException {
     Long imgSize = img.getImageSizeBytes( );
-    Long diskSize = vmType.getDisk( ) * 1024l * 1024l * 1024l;
+    Long diskSize = vmType.getDisk( ) * 1024L * 1024L * 1024L;
     
     if ( !( img instanceof BlockStorageImageInfo ) && imgSize > diskSize ) {
-      throw new InvalidMetadataException( "image too large [size=" + imgSize / ( 1024l * 1024l ) + "MB] for instance type " + vmType.getName( ) + " [disk="
-                                          + vmType.getDisk( ) * 1024l + "MB]" );
+      throw new InvalidMetadataException( "image too large [size=" + imgSize / ( 1024L * 1024L ) + "MB] for instance type " + vmType.getName( ) + " [disk="
+                                          + vmType.getDisk( ) * 1024L + "MB]" );
     }
-    VmTypeInfo vmTypeInfo = null;
+    VmTypeInfo vmTypeInfo;
     if ( img instanceof MachineImageInfo ) { // instance-store image
       if ( ImageMetadata.Platform.windows.equals( img.getPlatform( ) ) ) {
         vmTypeInfo = VmTypes.InstanceStoreWindowsVmTypeInfoMapper.INSTANCE.apply( vmType );
@@ -576,12 +592,12 @@ public class VmTypes {
         if ( ephemeralSize < MIN_EPHEMERAL_SIZE_BYTES ) {
           throw new InvalidMetadataException( "image too large to accommodate swap and ephemeral [size="
                                               + imgSize
-                                              / ( 1024l * 1024l )
+                                              / ( 1024L * 1024L )
                                               + "MB] for instance type "
                                               + vmType.getName( )
                                               + " [disk="
                                               + vmType.getDisk( )
-                                              * 1024l
+                                              * 1024L
                                               + "MB]" );
         }
         vmTypeInfo.setEphemeral( 0, "sda2", ephemeralSize,

--- a/clc/modules/compute-backend/src/test/java/com/eucalyptus/vm/InstanceTypesTemplateGenerator.groovy
+++ b/clc/modules/compute-backend/src/test/java/com/eucalyptus/vm/InstanceTypesTemplateGenerator.groovy
@@ -21,13 +21,54 @@ class InstanceTypesTemplateGenerator {
 
   @Test
   void test( ) {
+    String desc = ''
+    def filter = {
+      // backwards compat (have to edit parameters after create)
+      desc = 'Eucalyptus 4 '
+      [
+          'c1.medium',
+          'c1.xlarge',
+          'cc1.4xlarge',
+          'cc2.8xlarge',
+          'cg1.4xlarge',
+          'cr1.8xlarge',
+          'hi1.4xlarge',
+          'hs1.8xlarge',
+          'm1.large',
+          'm1.medium',
+          'm1.small',
+          'm1.xlarge',
+          'm2.2xlarge',
+          'm2.4xlarge',
+          'm2.xlarge',
+          'm3.2xlarge',
+          'm3.xlarge',
+          't1.micro',
+      ].contains(it.getName())
+
+      //desc = 'General '
+      //it.getName().startsWith('t') or it.getName().startsWith('m')
+
+      //desc = 'Compute Optimized '
+      //it.getName().startsWith('c')
+
+      //desc = 'Memory Optimized '
+      //it.getName().startsWith('r') or it.getName().startsWith('x')or it.getName().startsWith('z')
+
+      //desc = 'Storage Optimized '
+      //it.getName().startsWith('d') or it.getName().startsWith('h')or it.getName().startsWith('i')
+
+      //desc = 'Accelerated '
+      //it.getName().startsWith('f') or it.getName().startsWith('g')or it.getName().startsWith('p')
+    }
+    filter.call(VmTypes.PredefinedTypes.C1MEDIUM) // warmup ...
     print """\
-    AWSTemplateFormatVersion: "2010-09-09"
-    Description: EC2 Instance Types
+    AWSTemplateFormatVersion: 2010-09-09
+    Description: EC2 ${desc}Instance Types
     Parameters:
     """.stripIndent(4)
     Set<String> families = Sets.newTreeSet( )
-    families.addAll( VmTypes.PredefinedTypes.values( ).collect{ Strings.substringBefore( '.', it.getName()).toUpperCase() } )
+    families.addAll( VmTypes.PredefinedTypes.values( ).findAll(filter).collect{ Strings.substringBefore( '.', it.getName()).toUpperCase() } )
     families.each {
       print """\
       Enable${it}:
@@ -40,18 +81,23 @@ class InstanceTypesTemplateGenerator {
     print """\
     Resources:
     """.stripIndent(4)
-    VmTypes.PredefinedTypes.values( ).each{
-      print """\
-      ${it.getName().replace('.','').toUpperCase()}:
-        Type: AWS::EC2::InstanceType
+    families.each { familiy ->
+      String lastResourceForFamily = null
+      VmTypes.PredefinedTypes.values().findAll(filter).findAll{it.getName().startsWith(familiy.toLowerCase()+'.')}.each {
+        String resource = it.getName().replace('.', '').toUpperCase()
+        print """\
+      ${resource}:
+        Type: AWS::EC2::InstanceType${lastResourceForFamily==null ? '' : "\n        DependsOn: ${lastResourceForFamily}"}
         Properties:
           Name: ${it.getName()}
-          Enabled: !Ref Enable${Strings.substringBefore( '.', it.getName()).toUpperCase()}
+          Enabled: !Ref Enable${Strings.substringBefore('.', it.getName()).toUpperCase()}
           Cpu: ${it.getCpu()}
           Disk: ${it.getDisk()}
           Memory: ${it.getMemory()}
           NetworkInterfaces: ${it.getEthernetInterfaceLimit()}
       """.stripIndent(4)
+        lastResourceForFamily = resource
+      }
     }
   }
 }

--- a/clc/modules/compute-backend/src/test/java/com/eucalyptus/vm/InstanceTypesTemplateGenerator.groovy
+++ b/clc/modules/compute-backend/src/test/java/com/eucalyptus/vm/InstanceTypesTemplateGenerator.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.vm
+
+import com.eucalyptus.util.Strings
+import com.eucalyptus.vmtypes.VmTypes
+import com.google.common.collect.Sets
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Generated instance types CloudFormation template
+ */
+@Ignore("Developer test")
+class InstanceTypesTemplateGenerator {
+
+  @Test
+  void test( ) {
+    print """\
+    AWSTemplateFormatVersion: "2010-09-09"
+    Description: EC2 Instance Types
+    Parameters:
+    """.stripIndent(4)
+    Set<String> families = Sets.newTreeSet( )
+    families.addAll( VmTypes.PredefinedTypes.values( ).collect{ Strings.substringBefore( '.', it.getName()).toUpperCase() } )
+    families.each {
+      print """\
+      Enable${it}:
+        Description: Enable ${it} instance types
+        Type: String
+        AllowedValues: [ "True", "False" ]
+        Default: "${ it == 'T2' || it == 'M5' ? "True" : "False"}"
+      """.stripIndent(4)
+    }
+    print """\
+    Resources:
+    """.stripIndent(4)
+    VmTypes.PredefinedTypes.values( ).each{
+      print """\
+      ${it.getName().replace('.','').toUpperCase()}:
+        Type: AWS::EC2::InstanceType
+        Properties:
+          Name: ${it.getName()}
+          Enabled: !Ref Enable${Strings.substringBefore( '.', it.getName()).toUpperCase()}
+          Cpu: ${it.getCpu()}
+          Disk: ${it.getDisk()}
+          Memory: ${it.getMemory()}
+          NetworkInterfaces: ${it.getEthernetInterfaceLimit()}
+      """.stripIndent(4)
+    }
+  }
+}

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceTypeAttributeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceTypeAttributeType.java
@@ -43,8 +43,9 @@ public class ModifyInstanceTypeAttributeType extends VmTypeMessage {
   private Integer disk;
   @ComputeMessageValidation.FieldRange( min = 1l )
   private Integer memory;
-  @ComputeMessageValidation.FieldRange( min = 1l, max = 8l )
+  @ComputeMessageValidation.FieldRange( min = 1l, max = 15l )
   private Integer networkInterfaces;
+  private Boolean enabled;
 
   public Boolean getReset( ) {
     return reset;
@@ -100,5 +101,13 @@ public class ModifyInstanceTypeAttributeType extends VmTypeMessage {
 
   public void setNetworkInterfaces( Integer networkInterfaces ) {
     this.networkInterfaces = networkInterfaces;
+  }
+
+  public Boolean getEnabled( ) {
+    return enabled;
+  }
+
+  public void setEnabled( final Boolean enabled ) {
+    this.enabled = enabled;
   }
 }

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RunInstancesType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RunInstancesType.java
@@ -59,7 +59,7 @@ public class RunInstancesType extends VmControlMessage implements HasTags {
   private String version;
   private String encoding;
   private String addressingType;
-  private String instanceType = "m1.small";
+  private String instanceType;
   private String kernelId;
   private String ramdiskId;
   @HttpParameterMapping( parameter = "Placement.AvailabilityZone" )

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.compute.common;
+
+import com.eucalyptus.component.annotation.ComponentPart;
+
+/**
+ *
+ */
+@ComponentPart(Compute.class)
+public interface ComputeApi {
+
+  ModifyInstanceTypeAttributeResponseType modifyInstanceType( ModifyInstanceTypeAttributeType request );
+}

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmInstance.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmInstance.java
@@ -160,7 +160,7 @@ public class VmInstance extends UserMetadata<VmState> implements VmInstanceMetad
   private static final long    serialVersionUID = 1L;
   private static final Logger  LOG              = Logger.getLogger( VmInstance.class );
 
-  public static final String         DEFAULT_TYPE         = "m1.small";
+  public static final String         DEFAULT_TYPE         = "t2.micro";
   public static final String         ROOT_DEVICE_TYPE_EBS = "ebs";
   public static final String         ID_PREFIX            = "i";
   public static final String         VM_NC_HOST_TAG       = "euca:node";

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vmtypes/VmType.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vmtypes/VmType.java
@@ -47,6 +47,7 @@ import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.PersistenceContext;
+import javax.persistence.PostLoad;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
@@ -131,6 +132,9 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
   @Column( name = "config_vm_type_enis" )
   private Integer            networkInterfaces;
 
+  @Column( name = "config_vm_enabled" )
+  private Boolean            enabled;
+
   @ElementCollection
   @CollectionTable( name = "config_vm_types_ephemeral_disks" )
   private Set<EphemeralDisk> ephemeralDisks = Sets.newHashSet( );
@@ -147,13 +151,15 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
       final Integer cpu,
       final Integer disk,
       final Integer memory,
-      final Integer networkInterfaces
+      final Integer networkInterfaces,
+      final Boolean enabled
   ) {
     this( name );
     this.cpu = cpu;
     this.disk = disk;
     this.memory = memory;
     this.networkInterfaces = networkInterfaces;
+    this.enabled = enabled;
   }
   
   public static VmType create( ) {
@@ -200,7 +206,15 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
   public void setMemory( final Integer memory ) {
     this.memory = memory;
   }
-  
+
+  public Boolean getEnabled( ) {
+    return enabled;
+  }
+
+  public void setEnabled( final Boolean enabled ) {
+    this.enabled = enabled;
+  }
+
   @SuppressWarnings( "RedundantIfStatement" )
   @Override
   public boolean equals( final Object o ) {
@@ -269,7 +283,14 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
   public OwnerFullName getOwner( ) {
     return Principals.nobodyFullName( );
   }
-  
+
+  @PostLoad
+  private void onLoad( ) {
+    if ( enabled == null ) {
+      enabled = true;
+    }
+  }
+
   public Supplier<VmType> allocator( ) {
     return new Supplier<VmType>( ) {
       
@@ -388,8 +409,8 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
     return new VmType.EphemeralBuilder( this );
   }
   
-  public static VmType create( String name, Integer cpu, Integer disk, Integer memory, Integer networkInterfaces ) {
-    return new VmType( name, cpu, disk, memory, networkInterfaces );
+  public static VmType create( String name, Integer cpu, Integer disk, Integer memory, Integer networkInterfaces, Boolean enabled ) {
+    return new VmType( name, cpu, disk, memory, networkInterfaces, enabled );
   }
   
   public static VmType named( String name ) {

--- a/clc/modules/imaging-backend/src/main/resources/com/eucalyptus/imaging/worker/worker-cf-template.json
+++ b/clc/modules/imaging-backend/src/main/resources/com/eucalyptus/imaging/worker/worker-cf-template.json
@@ -13,7 +13,7 @@
       "Type": "String"
     },
     "InstanceType": {
-      "Default": "m1.small",
+      "Default": "t2.micro",
       "Type": "String"
     },
     "KeyName": {

--- a/clc/modules/imaging-common/src/main/java/com/eucalyptus/imaging/ImagingServiceProperties.java
+++ b/clc/modules/imaging-common/src/main/java/com/eucalyptus/imaging/ImagingServiceProperties.java
@@ -79,9 +79,9 @@ public class ImagingServiceProperties {
 
   @ConfigurableField(displayName = "instance_type",
       description = "instance type for imaging worker",
-      initial = "m1.small", readonly = false, type = ConfigurableFieldType.KEYVALUE,
+      initial = "t2.nano", readonly = false, type = ConfigurableFieldType.KEYVALUE,
       changeListener = PropertyChangeListeners.InstanceTypeChangeListener.class)
-  public static String INSTANCE_TYPE = "m1.small";
+  public static String INSTANCE_TYPE = "t2.nano";
 
   @ConfigurableField(displayName = "availability_zones",
       description = "availability zones for imaging worker",

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancingWorkerProperties.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancingWorkerProperties.java
@@ -67,11 +67,11 @@ public class LoadBalancingWorkerProperties {
 
   @ConfigurableField( displayName = "instance_type", 
       description = "instance type for loadbalancer instances",
-      initial = "m1.medium",
+      initial = "t2.nano",
       readonly = false,
       type = ConfigurableFieldType.KEYVALUE,
       changeListener = ElbInstanceTypeChangeListener.class)
-  public static String INSTANCE_TYPE = "m1.medium";
+  public static String INSTANCE_TYPE = "t2.nano";
 
   @ConfigurableField( displayName = "keyname", 
       description = "keyname to use when debugging loadbalancer VMs",

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -106,7 +106,8 @@ install: build
 	@$(INSTALL) -m 755 clusteradmin-register-nodes $(DESTDIR)$(sbindir)/clusteradmin-register-nodes
 	@$(INSTALL) -m 755 clusteradmin-register-nodes $(DESTDIR)$(sbindir)/clusteradmin-deregister-nodes
 	@$(INSTALL) -d $(DESTDIR)$(etcdir)/eucalyptus/cloud.d/elb-security-policy
-	@$(INSTALL) -m 755 elb-security-policy/*.json $(DESTDIR)$(etcdir)/eucalyptus/cloud.d/elb-security-policy/
+	@$(INSTALL) -m 644 elb-security-policy/*.json $(DESTDIR)$(etcdir)/eucalyptus/cloud.d/elb-security-policy/
+	@$(INSTALL) -m 644 cf-templates/*.yaml $(DESTDIR)$(datarootdir)/eucalyptus/doc/
 	@make -C status install
 	@make -C imaging install
 

--- a/tools/cf-templates/ec2-instance-types-accelerated.yaml
+++ b/tools/cf-templates/ec2-instance-types-accelerated.yaml
@@ -1,0 +1,165 @@
+# CloudFormation template for Accelerated EC2 InstanceTypes
+#
+# Parameters allow the enabled instance types to be customized:
+#
+#   euform-[create|update]-stack \
+#     --template-file ec2-instance-types-accelerated.yaml \
+#     -p EnableF1=True \
+#     ec2-instance-types-accelerated
+#
+# The eucalyptus account must be used for instance type resources.
+#
+AWSTemplateFormatVersion: 2010-09-09
+Description: EC2 Accelerated Instance Types
+Parameters:
+  EnableF1:
+    Description: Enable F1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableG2:
+    Description: Enable G2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableG3:
+    Description: Enable G3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableP2:
+    Description: Enable P2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableP3:
+    Description: Enable P3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+Resources:
+  F116XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: f1.16xlarge
+      Enabled: !Ref EnableF1
+      Cpu: 64
+      Disk: 3760
+      Memory: 999424
+      NetworkInterfaces: 8
+  F12XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: F116XLARGE
+    Properties:
+      Name: f1.2xlarge
+      Enabled: !Ref EnableF1
+      Cpu: 8
+      Disk: 470
+      Memory: 124928
+      NetworkInterfaces: 4
+  G22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: g2.2xlarge
+      Enabled: !Ref EnableG2
+      Cpu: 8
+      Disk: 60
+      Memory: 15360
+      NetworkInterfaces: 4
+  G28XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: G22XLARGE
+    Properties:
+      Name: g2.8xlarge
+      Enabled: !Ref EnableG2
+      Cpu: 32
+      Disk: 240
+      Memory: 61440
+      NetworkInterfaces: 8
+  G316XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: g3.16xlarge
+      Enabled: !Ref EnableG3
+      Cpu: 64
+      Disk: 160
+      Memory: 499712
+      NetworkInterfaces: 15
+  G34XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: G316XLARGE
+    Properties:
+      Name: g3.4xlarge
+      Enabled: !Ref EnableG3
+      Cpu: 16
+      Disk: 40
+      Memory: 124928
+      NetworkInterfaces: 8
+  G38XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: G34XLARGE
+    Properties:
+      Name: g3.8xlarge
+      Enabled: !Ref EnableG3
+      Cpu: 32
+      Disk: 80
+      Memory: 249856
+      NetworkInterfaces: 8
+  P216XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: p2.16xlarge
+      Enabled: !Ref EnableP2
+      Cpu: 64
+      Disk: 60
+      Memory: 749568
+      NetworkInterfaces: 8
+  P28XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: P216XLARGE
+    Properties:
+      Name: p2.8xlarge
+      Enabled: !Ref EnableP2
+      Cpu: 32
+      Disk: 40
+      Memory: 499712
+      NetworkInterfaces: 8
+  P2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: P28XLARGE
+    Properties:
+      Name: p2.xlarge
+      Enabled: !Ref EnableP2
+      Cpu: 4
+      Disk: 20
+      Memory: 62464
+      NetworkInterfaces: 4
+  P316XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: p3.16xlarge
+      Enabled: !Ref EnableP3
+      Cpu: 64
+      Disk: 80
+      Memory: 499712
+      NetworkInterfaces: 8
+  P32XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: P316XLARGE
+    Properties:
+      Name: p3.2xlarge
+      Enabled: !Ref EnableP3
+      Cpu: 8
+      Disk: 20
+      Memory: 62464
+      NetworkInterfaces: 4
+  P38XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: P32XLARGE
+    Properties:
+      Name: p3.8xlarge
+      Enabled: !Ref EnableP3
+      Cpu: 32
+      Disk: 40
+      Memory: 249856
+      NetworkInterfaces: 8

--- a/tools/cf-templates/ec2-instance-types-compute.yaml
+++ b/tools/cf-templates/ec2-instance-types-compute.yaml
@@ -1,0 +1,317 @@
+# CloudFormation template for Compute Optimized EC2 InstanceTypes
+#
+# Parameters allow the enabled instance types to be customized:
+#
+#   euform-[create|update]-stack \
+#     --template-file ec2-instance-types-compute.yaml \
+#     -p EnableC1=True \
+#     ec2-instance-types-compute
+#
+# The eucalyptus account must be used for instance type resources.
+#
+AWSTemplateFormatVersion: 2010-09-09
+Description: EC2 Compute Optimized Instance Types
+Parameters:
+  EnableC1:
+    Description: Enable C1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableC3:
+    Description: Enable C3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableC4:
+    Description: Enable C4 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableC5:
+    Description: Enable C5 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableC5D:
+    Description: Enable C5D instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableCC2:
+    Description: Enable CC2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableCG1:
+    Description: Enable CG1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableCR1:
+    Description: Enable CR1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+Resources:
+  C1MEDIUM:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: c1.medium
+      Enabled: !Ref EnableC1
+      Cpu: 2
+      Disk: 350
+      Memory: 1741
+      NetworkInterfaces: 2
+  C1XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C1MEDIUM
+    Properties:
+      Name: c1.xlarge
+      Enabled: !Ref EnableC1
+      Cpu: 8
+      Disk: 1680
+      Memory: 7168
+      NetworkInterfaces: 4
+  C32XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: c3.2xlarge
+      Enabled: !Ref EnableC3
+      Cpu: 8
+      Disk: 160
+      Memory: 15360
+      NetworkInterfaces: 4
+  C34XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C32XLARGE
+    Properties:
+      Name: c3.4xlarge
+      Enabled: !Ref EnableC3
+      Cpu: 16
+      Disk: 320
+      Memory: 30720
+      NetworkInterfaces: 8
+  C38XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C34XLARGE
+    Properties:
+      Name: c3.8xlarge
+      Enabled: !Ref EnableC3
+      Cpu: 32
+      Disk: 640
+      Memory: 61440
+      NetworkInterfaces: 8
+  C3LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C38XLARGE
+    Properties:
+      Name: c3.large
+      Enabled: !Ref EnableC3
+      Cpu: 2
+      Disk: 32
+      Memory: 3840
+      NetworkInterfaces: 3
+  C3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C3LARGE
+    Properties:
+      Name: c3.xlarge
+      Enabled: !Ref EnableC3
+      Cpu: 4
+      Disk: 80
+      Memory: 7680
+      NetworkInterfaces: 4
+  C42XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: c4.2xlarge
+      Enabled: !Ref EnableC4
+      Cpu: 8
+      Disk: 20
+      Memory: 15360
+      NetworkInterfaces: 4
+  C44XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C42XLARGE
+    Properties:
+      Name: c4.4xlarge
+      Enabled: !Ref EnableC4
+      Cpu: 16
+      Disk: 20
+      Memory: 30720
+      NetworkInterfaces: 8
+  C48XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C44XLARGE
+    Properties:
+      Name: c4.8xlarge
+      Enabled: !Ref EnableC4
+      Cpu: 36
+      Disk: 40
+      Memory: 61440
+      NetworkInterfaces: 8
+  C4LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C48XLARGE
+    Properties:
+      Name: c4.large
+      Enabled: !Ref EnableC4
+      Cpu: 2
+      Disk: 10
+      Memory: 3840
+      NetworkInterfaces: 3
+  C4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C4LARGE
+    Properties:
+      Name: c4.xlarge
+      Enabled: !Ref EnableC4
+      Cpu: 4
+      Disk: 15
+      Memory: 7680
+      NetworkInterfaces: 4
+  C518XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: c5.18xlarge
+      Enabled: !Ref EnableC5
+      Cpu: 72
+      Disk: 80
+      Memory: 147456
+      NetworkInterfaces: 15
+  C52XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C518XLARGE
+    Properties:
+      Name: c5.2xlarge
+      Enabled: !Ref EnableC5
+      Cpu: 8
+      Disk: 20
+      Memory: 16384
+      NetworkInterfaces: 4
+  C54XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C52XLARGE
+    Properties:
+      Name: c5.4xlarge
+      Enabled: !Ref EnableC5
+      Cpu: 16
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 8
+  C59XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C54XLARGE
+    Properties:
+      Name: c5.9xlarge
+      Enabled: !Ref EnableC5
+      Cpu: 36
+      Disk: 40
+      Memory: 73728
+      NetworkInterfaces: 8
+  C5LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C59XLARGE
+    Properties:
+      Name: c5.large
+      Enabled: !Ref EnableC5
+      Cpu: 2
+      Disk: 10
+      Memory: 4096
+      NetworkInterfaces: 3
+  C5XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C5LARGE
+    Properties:
+      Name: c5.xlarge
+      Enabled: !Ref EnableC5
+      Cpu: 4
+      Disk: 15
+      Memory: 8192
+      NetworkInterfaces: 4
+  C5D18XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: c5d.18xlarge
+      Enabled: !Ref EnableC5D
+      Cpu: 72
+      Disk: 1800
+      Memory: 147456
+      NetworkInterfaces: 15
+  C5D2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C5D18XLARGE
+    Properties:
+      Name: c5d.2xlarge
+      Enabled: !Ref EnableC5D
+      Cpu: 8
+      Disk: 200
+      Memory: 16384
+      NetworkInterfaces: 4
+  C5D4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C5D2XLARGE
+    Properties:
+      Name: c5d.4xlarge
+      Enabled: !Ref EnableC5D
+      Cpu: 16
+      Disk: 400
+      Memory: 32768
+      NetworkInterfaces: 8
+  C5D9XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C5D4XLARGE
+    Properties:
+      Name: c5d.9xlarge
+      Enabled: !Ref EnableC5D
+      Cpu: 36
+      Disk: 900
+      Memory: 73728
+      NetworkInterfaces: 8
+  C5DLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C5D9XLARGE
+    Properties:
+      Name: c5d.large
+      Enabled: !Ref EnableC5D
+      Cpu: 2
+      Disk: 50
+      Memory: 4096
+      NetworkInterfaces: 3
+  C5DXLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C5DLARGE
+    Properties:
+      Name: c5d.xlarge
+      Enabled: !Ref EnableC5D
+      Cpu: 4
+      Disk: 100
+      Memory: 8192
+      NetworkInterfaces: 4
+  CC28XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: cc2.8xlarge
+      Enabled: !Ref EnableCC2
+      Cpu: 32
+      Disk: 3360
+      Memory: 61952
+      NetworkInterfaces: 8
+  CG14XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: cg1.4xlarge
+      Enabled: !Ref EnableCG1
+      Cpu: 16
+      Disk: 200
+      Memory: 12288
+      NetworkInterfaces: 8
+  CR18XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: cr1.8xlarge
+      Enabled: !Ref EnableCR1
+      Cpu: 32
+      Disk: 240
+      Memory: 249856
+      NetworkInterfaces: 8

--- a/tools/cf-templates/ec2-instance-types-eucalyptus-4.yaml
+++ b/tools/cf-templates/ec2-instance-types-eucalyptus-4.yaml
@@ -1,0 +1,320 @@
+# CloudFormation template for Eucalyptus v4 compatible EC2 InstanceTypes
+#
+# Parameters allow the enabled instance types to be customized:
+#
+#   euform-[create|update]-stack \
+#     --template-file ec2-instance-types-eucalyptus-4.yaml \
+#     -p EnableCompat=True \
+#     ec2-instance-types-eucalyptus-4
+#
+# The eucalyptus account must be used for instance type resources.
+#
+AWSTemplateFormatVersion: 2010-09-09
+Description: EC2 Eucalyptus 4 Instance Types
+Parameters:
+  EnableCompat:
+    Description: Enable Eucalyptus v4 compatible instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "True"
+  EnableDefaults:
+    Description: Enable new default (T2, M5) instance types
+    Type: String
+    AllowedValues: [ "True", "False", "" ]
+    Default: ""
+Conditions:
+  EnableDefaultTypes:
+    Fn::Or:
+      - Fn::Equals: [ !Ref EnableDefaults, "True" ]
+      - Fn::And:
+        - Fn::Equals: [ !Ref EnableDefaults, "" ]
+        - Fn::Equals: [ !Ref EnableCompat, "False" ]
+Resources:
+  C1MEDIUM:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: c1.medium
+      Enabled: !Ref EnableCompat
+      Cpu: 2
+      Disk: 10
+      Memory: 512
+      NetworkInterfaces: 2
+  C1XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: C1MEDIUM
+    Properties:
+      Name: c1.xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 2
+      Disk: 10
+      Memory: 2048
+      NetworkInterfaces: 4
+  CC28XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: cc2.8xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 16
+      Disk: 120
+      Memory: 6144
+      NetworkInterfaces: 8
+  CG14XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: cg1.4xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 16
+      Disk: 200
+      Memory: 12288
+      NetworkInterfaces: 8
+  CR18XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: cr1.8xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 16
+      Disk: 240
+      Memory: 16384
+      NetworkInterfaces: 8
+  HI14XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: hi1.4xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 8
+      Disk: 120
+      Memory: 6144
+      NetworkInterfaces: 8
+  HS18XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: hs1.8xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 48
+      Disk: 24000
+      Memory: 119808
+      NetworkInterfaces: 8
+  M1LARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m1.large
+      Enabled: !Ref EnableCompat
+      Cpu: 2
+      Disk: 10
+      Memory: 512
+      NetworkInterfaces: 3
+  M1MEDIUM:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M1LARGE
+    Properties:
+      Name: m1.medium
+      Enabled: !Ref EnableCompat
+      Cpu: 1
+      Disk: 10
+      Memory: 512
+      NetworkInterfaces: 2
+  M1SMALL:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M1MEDIUM
+    Properties:
+      Name: m1.small
+      Enabled: !Ref EnableCompat
+      Cpu: 1
+      Disk: 5
+      Memory: 256
+      NetworkInterfaces: 2
+  M1XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M1SMALL
+    Properties:
+      Name: m1.xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 2
+      Disk: 10
+      Memory: 1024
+      NetworkInterfaces: 4
+  M22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m2.2xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 2
+      Disk: 30
+      Memory: 4096
+      NetworkInterfaces: 4
+  M24XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M22XLARGE
+    Properties:
+      Name: m2.4xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 8
+      Disk: 60
+      Memory: 4096
+      NetworkInterfaces: 8
+  M2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M24XLARGE
+    Properties:
+      Name: m2.xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 2
+      Disk: 10
+      Memory: 2048
+      NetworkInterfaces: 4
+  M32XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m3.2xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 4
+      Disk: 30
+      Memory: 4096
+      NetworkInterfaces: 4
+  M3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M32XLARGE
+    Properties:
+      Name: m3.xlarge
+      Enabled: !Ref EnableCompat
+      Cpu: 4
+      Disk: 15
+      Memory: 2048
+      NetworkInterfaces: 4
+  M512XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m5.12xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 48
+      Disk: 50
+      Memory: 196608
+      NetworkInterfaces: 8
+  M524XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M512XLARGE
+    Properties:
+      Name: m5.24xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 96
+      Disk: 100
+      Memory: 393216
+      NetworkInterfaces: 15
+  M52XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M524XLARGE
+    Properties:
+      Name: m5.2xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 8
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 4
+  M54XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M52XLARGE
+    Properties:
+      Name: m5.4xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 16
+      Disk: 20
+      Memory: 65536
+      NetworkInterfaces: 8
+  M5LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M54XLARGE
+    Properties:
+      Name: m5.large
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 2
+      Disk: 10
+      Memory: 8192
+      NetworkInterfaces: 3
+  M5XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5LARGE
+    Properties:
+      Name: m5.xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 4
+      Disk: 15
+      Memory: 16384
+      NetworkInterfaces: 4
+  T1MICRO:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: t1.micro
+      Enabled: !Ref EnableCompat
+      Cpu: 1
+      Disk: 5
+      Memory: 256
+      NetworkInterfaces: 2
+  T22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: t2.2xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 8
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 3
+  T2LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T22XLARGE
+    Properties:
+      Name: t2.large
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 2
+      Disk: 15
+      Memory: 8192
+      NetworkInterfaces: 3
+  T2MEDIUM:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2LARGE
+    Properties:
+      Name: t2.medium
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 2
+      Disk: 10
+      Memory: 4096
+      NetworkInterfaces: 3
+  T2MICRO:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2MEDIUM
+    Properties:
+      Name: t2.micro
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 1
+      Disk: 10
+      Memory: 1024
+      NetworkInterfaces: 2
+  T2NANO:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2MICRO
+    Properties:
+      Name: t2.nano
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 1
+      Disk: 5
+      Memory: 512
+      NetworkInterfaces: 2
+  T2SMALL:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2NANO
+    Properties:
+      Name: t2.small
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 1
+      Disk: 10
+      Memory: 2048
+      NetworkInterfaces: 2
+  T2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2SMALL
+    Properties:
+      Name: t2.xlarge
+      Enabled: !If [ EnableDefaultTypes, True, False ]
+      Cpu: 4
+      Disk: 15
+      Memory: 16384
+      NetworkInterfaces: 3

--- a/tools/cf-templates/ec2-instance-types-general.yaml
+++ b/tools/cf-templates/ec2-instance-types-general.yaml
@@ -1,0 +1,491 @@
+# CloudFormation template for General Purpose EC2 InstanceTypes
+# 
+# Parameters allow the enabled instance types to be customized:
+#
+#   euform-[create|update]-stack \
+#     --template-file ec2-instance-types-general.yaml \
+#     -p EnableM1=True \
+#     ec2-instance-types-general
+#
+# The eucalyptus account must be used for instance type resources.
+#
+AWSTemplateFormatVersion: 2010-09-09
+Description: EC2 General Instance Types
+Parameters:
+  EnableM1:
+    Description: Enable M1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableM2:
+    Description: Enable M2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableM3:
+    Description: Enable M3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableM4:
+    Description: Enable M4 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableM5:
+    Description: Enable M5 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "True"
+  EnableM5D:
+    Description: Enable M5D instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableT1:
+    Description: Enable T1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableT2:
+    Description: Enable T2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "True"
+  EnableT3:
+    Description: Enable T3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+Resources:
+  M1LARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m1.large
+      Enabled: !Ref EnableM1
+      Cpu: 2
+      Disk: 840
+      Memory: 7680
+      NetworkInterfaces: 3
+  M1MEDIUM:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M1LARGE
+    Properties:
+      Name: m1.medium
+      Enabled: !Ref EnableM1
+      Cpu: 1
+      Disk: 410
+      Memory: 3840
+      NetworkInterfaces: 2
+  M1SMALL:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M1MEDIUM
+    Properties:
+      Name: m1.small
+      Enabled: !Ref EnableM1
+      Cpu: 1
+      Disk: 160
+      Memory: 1741
+      NetworkInterfaces: 2
+  M1XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M1SMALL
+    Properties:
+      Name: m1.xlarge
+      Enabled: !Ref EnableM1
+      Cpu: 4
+      Disk: 1680
+      Memory: 15360
+      NetworkInterfaces: 4
+  M22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m2.2xlarge
+      Enabled: !Ref EnableM2
+      Cpu: 4
+      Disk: 850
+      Memory: 35021
+      NetworkInterfaces: 4
+  M24XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M22XLARGE
+    Properties:
+      Name: m2.4xlarge
+      Enabled: !Ref EnableM2
+      Cpu: 8
+      Disk: 1680
+      Memory: 70042
+      NetworkInterfaces: 8
+  M2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M24XLARGE
+    Properties:
+      Name: m2.xlarge
+      Enabled: !Ref EnableM2
+      Cpu: 2
+      Disk: 420
+      Memory: 17510
+      NetworkInterfaces: 4
+  M32XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m3.2xlarge
+      Enabled: !Ref EnableM3
+      Cpu: 8
+      Disk: 160
+      Memory: 30720
+      NetworkInterfaces: 4
+  M3LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M32XLARGE
+    Properties:
+      Name: m3.large
+      Enabled: !Ref EnableM3
+      Cpu: 2
+      Disk: 32
+      Memory: 7680
+      NetworkInterfaces: 3
+  M3MEDIUM:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M3LARGE
+    Properties:
+      Name: m3.medium
+      Enabled: !Ref EnableM3
+      Cpu: 1
+      Disk: 4
+      Memory: 3840
+      NetworkInterfaces: 2
+  M3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M3MEDIUM
+    Properties:
+      Name: m3.xlarge
+      Enabled: !Ref EnableM3
+      Cpu: 4
+      Disk: 80
+      Memory: 15360
+      NetworkInterfaces: 4
+  M410XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m4.10xlarge
+      Enabled: !Ref EnableM4
+      Cpu: 40
+      Disk: 40
+      Memory: 163840
+      NetworkInterfaces: 8
+  M416XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M410XLARGE
+    Properties:
+      Name: m4.16xlarge
+      Enabled: !Ref EnableM4
+      Cpu: 64
+      Disk: 60
+      Memory: 262144
+      NetworkInterfaces: 8
+  M42XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M416XLARGE
+    Properties:
+      Name: m4.2xlarge
+      Enabled: !Ref EnableM4
+      Cpu: 8
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 4
+  M44XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M42XLARGE
+    Properties:
+      Name: m4.4xlarge
+      Enabled: !Ref EnableM4
+      Cpu: 16
+      Disk: 20
+      Memory: 65536
+      NetworkInterfaces: 8
+  M4LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M44XLARGE
+    Properties:
+      Name: m4.large
+      Enabled: !Ref EnableM4
+      Cpu: 2
+      Disk: 10
+      Memory: 8192
+      NetworkInterfaces: 2
+  M4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M4LARGE
+    Properties:
+      Name: m4.xlarge
+      Enabled: !Ref EnableM4
+      Cpu: 4
+      Disk: 15
+      Memory: 16384
+      NetworkInterfaces: 4
+  M512XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m5.12xlarge
+      Enabled: !Ref EnableM5
+      Cpu: 48
+      Disk: 50
+      Memory: 196608
+      NetworkInterfaces: 8
+  M524XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M512XLARGE
+    Properties:
+      Name: m5.24xlarge
+      Enabled: !Ref EnableM5
+      Cpu: 96
+      Disk: 100
+      Memory: 393216
+      NetworkInterfaces: 15
+  M52XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M524XLARGE
+    Properties:
+      Name: m5.2xlarge
+      Enabled: !Ref EnableM5
+      Cpu: 8
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 4
+  M54XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M52XLARGE
+    Properties:
+      Name: m5.4xlarge
+      Enabled: !Ref EnableM5
+      Cpu: 16
+      Disk: 20
+      Memory: 65536
+      NetworkInterfaces: 8
+  M5LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M54XLARGE
+    Properties:
+      Name: m5.large
+      Enabled: !Ref EnableM5
+      Cpu: 2
+      Disk: 10
+      Memory: 8192
+      NetworkInterfaces: 3
+  M5XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5LARGE
+    Properties:
+      Name: m5.xlarge
+      Enabled: !Ref EnableM5
+      Cpu: 4
+      Disk: 15
+      Memory: 16384
+      NetworkInterfaces: 4
+  M5D12XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: m5d.12xlarge
+      Enabled: !Ref EnableM5D
+      Cpu: 48
+      Disk: 1800
+      Memory: 196608
+      NetworkInterfaces: 8
+  M5D24XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5D12XLARGE
+    Properties:
+      Name: m5d.24xlarge
+      Enabled: !Ref EnableM5D
+      Cpu: 96
+      Disk: 3600
+      Memory: 393216
+      NetworkInterfaces: 15
+  M5D2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5D24XLARGE
+    Properties:
+      Name: m5d.2xlarge
+      Enabled: !Ref EnableM5D
+      Cpu: 8
+      Disk: 300
+      Memory: 32768
+      NetworkInterfaces: 4
+  M5D4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5D2XLARGE
+    Properties:
+      Name: m5d.4xlarge
+      Enabled: !Ref EnableM5D
+      Cpu: 16
+      Disk: 600
+      Memory: 65536
+      NetworkInterfaces: 8
+  M5DLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5D4XLARGE
+    Properties:
+      Name: m5d.large
+      Enabled: !Ref EnableM5D
+      Cpu: 2
+      Disk: 75
+      Memory: 8192
+      NetworkInterfaces: 3
+  M5DXLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: M5DLARGE
+    Properties:
+      Name: m5d.xlarge
+      Enabled: !Ref EnableM5D
+      Cpu: 4
+      Disk: 150
+      Memory: 16384
+      NetworkInterfaces: 4
+  T1MICRO:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: t1.micro
+      Enabled: !Ref EnableT1
+      Cpu: 1
+      Disk: 5
+      Memory: 628
+      NetworkInterfaces: 2
+  T22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: t2.2xlarge
+      Enabled: !Ref EnableT2
+      Cpu: 8
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 3
+  T2LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T22XLARGE
+    Properties:
+      Name: t2.large
+      Enabled: !Ref EnableT2
+      Cpu: 2
+      Disk: 15
+      Memory: 8192
+      NetworkInterfaces: 3
+  T2MEDIUM:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2LARGE
+    Properties:
+      Name: t2.medium
+      Enabled: !Ref EnableT2
+      Cpu: 2
+      Disk: 10
+      Memory: 4096
+      NetworkInterfaces: 3
+  T2MICRO:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2MEDIUM
+    Properties:
+      Name: t2.micro
+      Enabled: !Ref EnableT2
+      Cpu: 1
+      Disk: 10
+      Memory: 1024
+      NetworkInterfaces: 2
+  T2NANO:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2MICRO
+    Properties:
+      Name: t2.nano
+      Enabled: !Ref EnableT2
+      Cpu: 1
+      Disk: 5
+      Memory: 512
+      NetworkInterfaces: 2
+  T2SMALL:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2NANO
+    Properties:
+      Name: t2.small
+      Enabled: !Ref EnableT2
+      Cpu: 1
+      Disk: 10
+      Memory: 2048
+      NetworkInterfaces: 2
+  T2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T2SMALL
+    Properties:
+      Name: t2.xlarge
+      Enabled: !Ref EnableT2
+      Cpu: 4
+      Disk: 15
+      Memory: 16384
+      NetworkInterfaces: 3
+  T32XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: t3.2xlarge
+      Enabled: !Ref EnableT3
+      Cpu: 8
+      Disk: 20
+      Memory: 32768
+      NetworkInterfaces: 4
+  T3LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T32XLARGE
+    Properties:
+      Name: t3.large
+      Enabled: !Ref EnableT3
+      Cpu: 2
+      Disk: 15
+      Memory: 8192
+      NetworkInterfaces: 3
+  T3MEDIUM:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T3LARGE
+    Properties:
+      Name: t3.medium
+      Enabled: !Ref EnableT3
+      Cpu: 2
+      Disk: 10
+      Memory: 4096
+      NetworkInterfaces: 3
+  T3MICRO:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T3MEDIUM
+    Properties:
+      Name: t3.micro
+      Enabled: !Ref EnableT3
+      Cpu: 1
+      Disk: 10
+      Memory: 1024
+      NetworkInterfaces: 2
+  T3NANO:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T3MICRO
+    Properties:
+      Name: t3.nano
+      Enabled: !Ref EnableT3
+      Cpu: 1
+      Disk: 5
+      Memory: 512
+      NetworkInterfaces: 2
+  T3SMALL:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T3NANO
+    Properties:
+      Name: t3.small
+      Enabled: !Ref EnableT3
+      Cpu: 1
+      Disk: 10
+      Memory: 2048
+      NetworkInterfaces: 2
+  T3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: T3SMALL
+    Properties:
+      Name: t3.xlarge
+      Enabled: !Ref EnableT3
+      Cpu: 4
+      Disk: 15
+      Memory: 16384
+      NetworkInterfaces: 4

--- a/tools/cf-templates/ec2-instance-types-memory.yaml
+++ b/tools/cf-templates/ec2-instance-types-memory.yaml
@@ -1,0 +1,413 @@
+# CloudFormation template for Memory Optimized EC2 InstanceTypes
+#
+# Parameters allow the enabled instance types to be customized:
+#
+#   euform-[create|update]-stack \
+#     --template-file ec2-instance-types-memory.yaml \
+#     -p EnableR3=True \
+#     ec2-instance-types-memory
+#
+# The eucalyptus account must be used for instance type resources.
+#
+AWSTemplateFormatVersion: 2010-09-09
+Description: EC2 Memory Optimized Instance Types
+Parameters:
+  EnableR3:
+    Description: Enable R3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableR4:
+    Description: Enable R4 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableR5:
+    Description: Enable R5 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableR5D:
+    Description: Enable R5D instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableX1:
+    Description: Enable X1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableX1E:
+    Description: Enable X1E instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableZ1D:
+    Description: Enable Z1D instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+Resources:
+  R32XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: r3.2xlarge
+      Enabled: !Ref EnableR3
+      Cpu: 8
+      Disk: 160
+      Memory: 62464
+      NetworkInterfaces: 4
+  R34XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R32XLARGE
+    Properties:
+      Name: r3.4xlarge
+      Enabled: !Ref EnableR3
+      Cpu: 16
+      Disk: 320
+      Memory: 124928
+      NetworkInterfaces: 8
+  R38XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R34XLARGE
+    Properties:
+      Name: r3.8xlarge
+      Enabled: !Ref EnableR3
+      Cpu: 32
+      Disk: 640
+      Memory: 249856
+      NetworkInterfaces: 8
+  R3LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R38XLARGE
+    Properties:
+      Name: r3.large
+      Enabled: !Ref EnableR3
+      Cpu: 2
+      Disk: 32
+      Memory: 15616
+      NetworkInterfaces: 3
+  R3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R3LARGE
+    Properties:
+      Name: r3.xlarge
+      Enabled: !Ref EnableR3
+      Cpu: 4
+      Disk: 80
+      Memory: 31232
+      NetworkInterfaces: 4
+  R416XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: r4.16xlarge
+      Enabled: !Ref EnableR4
+      Cpu: 64
+      Disk: 60
+      Memory: 499712
+      NetworkInterfaces: 15
+  R42XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R416XLARGE
+    Properties:
+      Name: r4.2xlarge
+      Enabled: !Ref EnableR4
+      Cpu: 8
+      Disk: 20
+      Memory: 62464
+      NetworkInterfaces: 4
+  R44XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R42XLARGE
+    Properties:
+      Name: r4.4xlarge
+      Enabled: !Ref EnableR4
+      Cpu: 16
+      Disk: 20
+      Memory: 124928
+      NetworkInterfaces: 8
+  R48XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R44XLARGE
+    Properties:
+      Name: r4.8xlarge
+      Enabled: !Ref EnableR4
+      Cpu: 32
+      Disk: 40
+      Memory: 249856
+      NetworkInterfaces: 8
+  R4LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R48XLARGE
+    Properties:
+      Name: r4.large
+      Enabled: !Ref EnableR4
+      Cpu: 2
+      Disk: 10
+      Memory: 15616
+      NetworkInterfaces: 3
+  R4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R4LARGE
+    Properties:
+      Name: r4.xlarge
+      Enabled: !Ref EnableR4
+      Cpu: 4
+      Disk: 15
+      Memory: 31232
+      NetworkInterfaces: 4
+  R512XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: r5.12xlarge
+      Enabled: !Ref EnableR5
+      Cpu: 48
+      Disk: 50
+      Memory: 393216
+      NetworkInterfaces: 8
+  R524XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R512XLARGE
+    Properties:
+      Name: r5.24xlarge
+      Enabled: !Ref EnableR5
+      Cpu: 96
+      Disk: 100
+      Memory: 786432
+      NetworkInterfaces: 15
+  R52XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R524XLARGE
+    Properties:
+      Name: r5.2xlarge
+      Enabled: !Ref EnableR5
+      Cpu: 8
+      Disk: 20
+      Memory: 65536
+      NetworkInterfaces: 4
+  R54XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R52XLARGE
+    Properties:
+      Name: r5.4xlarge
+      Enabled: !Ref EnableR5
+      Cpu: 16
+      Disk: 20
+      Memory: 131072
+      NetworkInterfaces: 8
+  R5LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R54XLARGE
+    Properties:
+      Name: r5.large
+      Enabled: !Ref EnableR5
+      Cpu: 2
+      Disk: 10
+      Memory: 16384
+      NetworkInterfaces: 3
+  R5XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R5LARGE
+    Properties:
+      Name: r5.xlarge
+      Enabled: !Ref EnableR5
+      Cpu: 4
+      Disk: 15
+      Memory: 32768
+      NetworkInterfaces: 4
+  R5D12XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: r5d.12xlarge
+      Enabled: !Ref EnableR5D
+      Cpu: 48
+      Disk: 1800
+      Memory: 393216
+      NetworkInterfaces: 8
+  R5D24XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R5D12XLARGE
+    Properties:
+      Name: r5d.24xlarge
+      Enabled: !Ref EnableR5D
+      Cpu: 96
+      Disk: 3600
+      Memory: 786432
+      NetworkInterfaces: 15
+  R5D2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R5D24XLARGE
+    Properties:
+      Name: r5d.2xlarge
+      Enabled: !Ref EnableR5D
+      Cpu: 8
+      Disk: 300
+      Memory: 65536
+      NetworkInterfaces: 4
+  R5D4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R5D2XLARGE
+    Properties:
+      Name: r5d.4xlarge
+      Enabled: !Ref EnableR5D
+      Cpu: 16
+      Disk: 600
+      Memory: 131072
+      NetworkInterfaces: 8
+  R5DLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R5D4XLARGE
+    Properties:
+      Name: r5d.large
+      Enabled: !Ref EnableR5D
+      Cpu: 2
+      Disk: 75
+      Memory: 16384
+      NetworkInterfaces: 3
+  R5DXLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: R5DLARGE
+    Properties:
+      Name: r5d.xlarge
+      Enabled: !Ref EnableR5D
+      Cpu: 4
+      Disk: 150
+      Memory: 32768
+      NetworkInterfaces: 4
+  X116XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: x1.16xlarge
+      Enabled: !Ref EnableX1
+      Cpu: 64
+      Disk: 1920
+      Memory: 999424
+      NetworkInterfaces: 8
+  X132XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: X116XLARGE
+    Properties:
+      Name: x1.32xlarge
+      Enabled: !Ref EnableX1
+      Cpu: 128
+      Disk: 3840
+      Memory: 1998848
+      NetworkInterfaces: 8
+  X1E16XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: x1e.16xlarge
+      Enabled: !Ref EnableX1E
+      Cpu: 64
+      Disk: 1920
+      Memory: 1998848
+      NetworkInterfaces: 8
+  X1E2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: X1E16XLARGE
+    Properties:
+      Name: x1e.2xlarge
+      Enabled: !Ref EnableX1E
+      Cpu: 8
+      Disk: 240
+      Memory: 249856
+      NetworkInterfaces: 4
+  X1E32XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: X1E2XLARGE
+    Properties:
+      Name: x1e.32xlarge
+      Enabled: !Ref EnableX1E
+      Cpu: 128
+      Disk: 3840
+      Memory: 3997696
+      NetworkInterfaces: 8
+  X1E4XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: X1E32XLARGE
+    Properties:
+      Name: x1e.4xlarge
+      Enabled: !Ref EnableX1E
+      Cpu: 16
+      Disk: 480
+      Memory: 499712
+      NetworkInterfaces: 4
+  X1E8XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: X1E4XLARGE
+    Properties:
+      Name: x1e.8xlarge
+      Enabled: !Ref EnableX1E
+      Cpu: 32
+      Disk: 960
+      Memory: 999424
+      NetworkInterfaces: 4
+  X1EXLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: X1E8XLARGE
+    Properties:
+      Name: x1e.xlarge
+      Enabled: !Ref EnableX1E
+      Cpu: 4
+      Disk: 120
+      Memory: 124928
+      NetworkInterfaces: 3
+  Z1D12XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: z1d.12xlarge
+      Enabled: !Ref EnableZ1D
+      Cpu: 48
+      Disk: 1800
+      Memory: 393216
+      NetworkInterfaces: 15
+  Z1D2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: Z1D12XLARGE
+    Properties:
+      Name: z1d.2xlarge
+      Enabled: !Ref EnableZ1D
+      Cpu: 8
+      Disk: 300
+      Memory: 65536
+      NetworkInterfaces: 4
+  Z1D3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: Z1D2XLARGE
+    Properties:
+      Name: z1d.3xlarge
+      Enabled: !Ref EnableZ1D
+      Cpu: 12
+      Disk: 450
+      Memory: 98304
+      NetworkInterfaces: 8
+  Z1D6XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: Z1D3XLARGE
+    Properties:
+      Name: z1d.6xlarge
+      Enabled: !Ref EnableZ1D
+      Cpu: 24
+      Disk: 900
+      Memory: 196608
+      NetworkInterfaces: 8
+  Z1DLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: Z1D6XLARGE
+    Properties:
+      Name: z1d.large
+      Enabled: !Ref EnableZ1D
+      Cpu: 2
+      Disk: 75
+      Memory: 16384
+      NetworkInterfaces: 3
+  Z1DXLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: Z1DLARGE
+    Properties:
+      Name: z1d.xlarge
+      Enabled: !Ref EnableZ1D
+      Cpu: 4
+      Disk: 150
+      Memory: 32768
+      NetworkInterfaces: 4

--- a/tools/cf-templates/ec2-instance-types-storage.yaml
+++ b/tools/cf-templates/ec2-instance-types-storage.yaml
@@ -1,0 +1,239 @@
+# CloudFormation template for Storage Optimized EC2 InstanceTypes
+#
+# Parameters allow the enabled instance types to be customized:
+#
+#   euform-[create|update]-stack \
+#     --template-file ec2-instance-types-storage.yaml \
+#     -p EnableD2=True \
+#     ec2-instance-types-storage
+#
+# The eucalyptus account must be used for instance type resources.
+#
+AWSTemplateFormatVersion: 2010-09-09
+Description: EC2 Storage Optimized Instance Types
+Parameters:
+  EnableD2:
+    Description: Enable D2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableH1:
+    Description: Enable H1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableHI1:
+    Description: Enable HI1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableHS1:
+    Description: Enable HS1 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableI2:
+    Description: Enable I2 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+  EnableI3:
+    Description: Enable I3 instance types
+    Type: String
+    AllowedValues: [ "True", "False" ]
+    Default: "False"
+Resources:
+  D22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: d2.2xlarge
+      Enabled: !Ref EnableD2
+      Cpu: 8
+      Disk: 12000
+      Memory: 62464
+      NetworkInterfaces: 4
+  D24XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: D22XLARGE
+    Properties:
+      Name: d2.4xlarge
+      Enabled: !Ref EnableD2
+      Cpu: 16
+      Disk: 24000
+      Memory: 124928
+      NetworkInterfaces: 8
+  D28XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: D24XLARGE
+    Properties:
+      Name: d2.8xlarge
+      Enabled: !Ref EnableD2
+      Cpu: 36
+      Disk: 48000
+      Memory: 249856
+      NetworkInterfaces: 8
+  D2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: D28XLARGE
+    Properties:
+      Name: d2.xlarge
+      Enabled: !Ref EnableD2
+      Cpu: 4
+      Disk: 6000
+      Memory: 31232
+      NetworkInterfaces: 4
+  H116XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: h1.16xlarge
+      Enabled: !Ref EnableH1
+      Cpu: 64
+      Disk: 16000
+      Memory: 262144
+      NetworkInterfaces: 15
+  H12XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: H116XLARGE
+    Properties:
+      Name: h1.2xlarge
+      Enabled: !Ref EnableH1
+      Cpu: 8
+      Disk: 2000
+      Memory: 32768
+      NetworkInterfaces: 4
+  H14XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: H12XLARGE
+    Properties:
+      Name: h1.4xlarge
+      Enabled: !Ref EnableH1
+      Cpu: 16
+      Disk: 4000
+      Memory: 65536
+      NetworkInterfaces: 8
+  H18XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: H14XLARGE
+    Properties:
+      Name: h1.8xlarge
+      Enabled: !Ref EnableH1
+      Cpu: 32
+      Disk: 8000
+      Memory: 131072
+      NetworkInterfaces: 8
+  HI14XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: hi1.4xlarge
+      Enabled: !Ref EnableHI1
+      Cpu: 48
+      Disk: 24000
+      Memory: 119808
+      NetworkInterfaces: 8
+  HS18XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: hs1.8xlarge
+      Enabled: !Ref EnableHS1
+      Cpu: 16
+      Disk: 48000
+      Memory: 119808
+      NetworkInterfaces: 8
+  I22XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: i2.2xlarge
+      Enabled: !Ref EnableI2
+      Cpu: 8
+      Disk: 1600
+      Memory: 62464
+      NetworkInterfaces: 4
+  I24XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I22XLARGE
+    Properties:
+      Name: i2.4xlarge
+      Enabled: !Ref EnableI2
+      Cpu: 16
+      Disk: 3200
+      Memory: 124928
+      NetworkInterfaces: 8
+  I28XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I24XLARGE
+    Properties:
+      Name: i2.8xlarge
+      Enabled: !Ref EnableI2
+      Cpu: 32
+      Disk: 6400
+      Memory: 249856
+      NetworkInterfaces: 8
+  I2XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I28XLARGE
+    Properties:
+      Name: i2.xlarge
+      Enabled: !Ref EnableI2
+      Cpu: 4
+      Disk: 800
+      Memory: 31232
+      NetworkInterfaces: 4
+  I316XLARGE:
+    Type: AWS::EC2::InstanceType
+    Properties:
+      Name: i3.16xlarge
+      Enabled: !Ref EnableI3
+      Cpu: 64
+      Disk: 15200
+      Memory: 499712
+      NetworkInterfaces: 15
+  I32XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I316XLARGE
+    Properties:
+      Name: i3.2xlarge
+      Enabled: !Ref EnableI3
+      Cpu: 8
+      Disk: 1900
+      Memory: 62464
+      NetworkInterfaces: 4
+  I34XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I32XLARGE
+    Properties:
+      Name: i3.4xlarge
+      Enabled: !Ref EnableI3
+      Cpu: 16
+      Disk: 3800
+      Memory: 124928
+      NetworkInterfaces: 8
+  I38XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I34XLARGE
+    Properties:
+      Name: i3.8xlarge
+      Enabled: !Ref EnableI3
+      Cpu: 32
+      Disk: 7600
+      Memory: 249856
+      NetworkInterfaces: 8
+  I3LARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I38XLARGE
+    Properties:
+      Name: i3.large
+      Enabled: !Ref EnableI3
+      Cpu: 2
+      Disk: 475
+      Memory: 15616
+      NetworkInterfaces: 3
+  I3XLARGE:
+    Type: AWS::EC2::InstanceType
+    DependsOn: I3LARGE
+    Properties:
+      Name: i3.xlarge
+      Enabled: !Ref EnableI3
+      Cpu: 4
+      Disk: 950
+      Memory: 31232
+      NetworkInterfaces: 4


### PR DESCRIPTION
Update to support more instance types and to allow types to be enabled/disabled. By default we now enable only t2.*/m5.* instance types. CloudFormation is updated to support ec2 instance types (for cloud administrator use) and we provide templates for enabling/disabling groups of types:

* c2-instance-types-eucalyptus-4.yaml : This template enables only eucalyptus v4 types
* ec2-instance-types-general.yaml : General instance types template, (t, m)
* ec2-instance-types-accelerated.yaml : Accelerated instance types (f,g,p)
* ec2-instance-types-compute.yaml : Compute optimized instance types (c)
* ec2-instance-types-memory.yaml : Memory optimized instance types (r,x,z)
* ec2-instance-types-storage.yaml : Storage optimized instance types (d,h,i)

For example, to enable d2 instance types:

```
# euform-[create|update]-stack \
#     --template-file ec2-instance-types-storage.yaml \
#     -p EnableD2=True \
#     ec2-instance-types-storage
```

Users can use these templates as examples and create their own templates enabling their preferred types with whatever parameters are desired for their deployment.

The default types for ec2 and the imaging/loadbalancing vms are updated to use types that are now available by default.