### PR TITLE
EC2 VPC elastic ip tags

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2EIPResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2EIPResourceAction.java
@@ -36,8 +36,10 @@ import com.eucalyptus.cloudformation.resources.EC2Helper;
 import com.eucalyptus.cloudformation.resources.ResourceAction;
 import com.eucalyptus.cloudformation.resources.ResourceInfo;
 import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.standard.TagHelper;
 import com.eucalyptus.cloudformation.resources.standard.info.AWSEC2EIPResourceInfo;
 import com.eucalyptus.cloudformation.resources.standard.propertytypes.AWSEC2EIPProperties;
+import com.eucalyptus.cloudformation.resources.standard.propertytypes.EC2Tag;
 import com.eucalyptus.cloudformation.template.JsonHelper;
 import com.eucalyptus.cloudformation.util.MessageHelper;
 import com.eucalyptus.cloudformation.workflow.steps.Step;
@@ -53,21 +55,30 @@ import com.eucalyptus.compute.common.AssociateAddressResponseType;
 import com.eucalyptus.compute.common.AssociateAddressType;
 import com.eucalyptus.compute.common.CloudFilters;
 import com.eucalyptus.compute.common.Compute;
+import com.eucalyptus.compute.common.ComputeApi;
+import com.eucalyptus.compute.common.CreateTagsType;
+import com.eucalyptus.compute.common.DeleteTagsType;
 import com.eucalyptus.compute.common.DescribeAddressesResponseType;
 import com.eucalyptus.compute.common.DescribeAddressesType;
 import com.eucalyptus.compute.common.DescribeInstancesResponseType;
 import com.eucalyptus.compute.common.DescribeInstancesType;
+import com.eucalyptus.compute.common.DescribeTagsResponseType;
+import com.eucalyptus.compute.common.DescribeTagsType;
 import com.eucalyptus.compute.common.DisassociateAddressResponseType;
 import com.eucalyptus.compute.common.DisassociateAddressType;
 import com.eucalyptus.compute.common.ReleaseAddressResponseType;
 import com.eucalyptus.compute.common.ReleaseAddressType;
+import com.eucalyptus.compute.common.TagInfo;
+import com.eucalyptus.util.async.AsyncProxy;
 import com.eucalyptus.util.async.AsyncRequests;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 
 
 /**
@@ -127,13 +138,45 @@ public class AWSEC2EIPResourceAction extends StepBasedResourceAction {
         if (action.properties.getDomain() != null) {
           allocateAddressType.setDomain(action.properties.getDomain());
         }
-        AllocateAddressResponseType allocateAddressResponseType = AsyncRequests.<AllocateAddressType, AllocateAddressResponseType> sendSync(configuration, allocateAddressType);
+        AllocateAddressResponseType allocateAddressResponseType = AsyncRequests.sendSync(configuration, allocateAddressType);
         String publicIp = allocateAddressResponseType.getPublicIp();
         action.info.setPhysicalResourceId(publicIp);
         action.info.setCreatedEnoughToDelete(true);
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         if (action.properties.getDomain() != null) {
           action.info.setAllocationId(JsonHelper.getStringFromJsonNode(new TextNode(allocateAddressResponseType.getAllocationId())));
+        }
+        return action;
+      }
+    },
+    CREATE_TAGS {
+      @Override
+      public ResourceAction perform(final ResourceAction resourceAction) throws Exception {
+        final AWSEC2EIPResourceAction action = (AWSEC2EIPResourceAction) resourceAction;
+        if ( action.info.getAllocationId( ) != null ) {
+          final String allocationId = JsonHelper.getJsonNodeFromString(action.info.getAllocationId()).asText();
+          // Create 'system' tags as admin user
+          final String effectiveAdminUserId = action.info.getAccountId( );
+          final CreateTagsType createSystemTagsType = MessageHelper.createPrivilegedMessage( CreateTagsType.class, effectiveAdminUserId );
+          createSystemTagsType.setResourcesSet( Lists.newArrayList( allocationId ) );
+          createSystemTagsType.setTagSet( EC2Helper.createTagSet( TagHelper.getEC2SystemTags( action.info, action.getStackEntity( ) ) ) );
+          AsyncProxy.client( ComputeApi.class, Function.identity( ) ).createTags(
+              createSystemTagsType
+          );
+          // Create non-system tags as regular user
+          final List<EC2Tag> tags = TagHelper.getEC2StackTags( action.getStackEntity( ) );
+          if ( action.properties.getTags( ) != null && !action.properties.getTags( ).isEmpty( ) ) {
+            TagHelper.checkReservedEC2TemplateTags( action.properties.getTags( ) );
+            tags.addAll( action.properties.getTags( ) );
+          }
+          if ( !tags.isEmpty( ) ) {
+            final CreateTagsType createTagsType = MessageHelper.createMessage( CreateTagsType.class, action.info.getEffectiveUserId( ) );
+            createTagsType.setResourcesSet( Lists.newArrayList( allocationId ) );
+            createTagsType.setTagSet( EC2Helper.createTagSet( tags ) );
+            AsyncProxy.client( ComputeApi.class, Function.identity( ) ).createTags(
+                createTagsType
+            );
+          }
         }
         return action;
       }
@@ -226,8 +269,6 @@ public class AWSEC2EIPResourceAction extends StepBasedResourceAction {
     }
   }
 
-
-
   @Override
   public ResourceProperties getResourceProperties() {
     return properties;
@@ -308,6 +349,63 @@ public class AWSEC2EIPResourceAction extends StepBasedResourceAction {
             if (newAction.properties.getInstanceId() != null) {
               EC2Helper.refreshInstanceAttributes(newAction.getStackEntity(), newAction.properties.getInstanceId(), newAction.info.getEffectiveUserId(), newAction.getStackEntity().getStackVersion());
             }
+          }
+        }
+        return newAction;
+      }
+    },
+    UPDATE_TAGS {
+      @Override
+      public ResourceAction perform(ResourceAction oldResourceAction, ResourceAction newResourceAction) throws Exception {
+        final AWSEC2EIPResourceAction oldAction = (AWSEC2EIPResourceAction) oldResourceAction;
+        final AWSEC2EIPResourceAction newAction = (AWSEC2EIPResourceAction) newResourceAction;
+        if ( oldAction.info.getAllocationId( ) != null &&
+            newAction.info.getAllocationId( ) != null ) {
+          final ComputeApi compute = AsyncProxy.client( ComputeApi.class, Function.identity( ) );
+          final String allocationId = JsonHelper.getJsonNodeFromString(newAction.info.getAllocationId()).asText();
+          final DescribeTagsType describeTagsType = MessageHelper.createMessage(DescribeTagsType.class, newAction.info.getEffectiveUserId());
+          describeTagsType.setFilterSet(Lists.newArrayList(CloudFilters.filter("resource-id", allocationId)));
+          final DescribeTagsResponseType describeTagsResponseType = compute.describeTags(describeTagsType);
+          final Set<EC2Tag> existingTags = Sets.newLinkedHashSet();
+          if (describeTagsResponseType != null && describeTagsResponseType.getTagSet() != null) {
+            for (final TagInfo tagInfo: describeTagsResponseType.getTagSet()) {
+              existingTags.add( new EC2Tag( tagInfo.getKey( ), tagInfo.getValue() )  );
+            }
+          }
+          final Set<EC2Tag> newTags = Sets.newLinkedHashSet();
+          if (newAction.properties.getTags() != null) {
+            newTags.addAll(newAction.properties.getTags());
+          }
+          final List<EC2Tag> newStackTags = TagHelper.getEC2StackTags(newAction.getStackEntity());
+          if (newStackTags != null) {
+            newTags.addAll(newStackTags);
+          }
+          TagHelper.checkReservedEC2TemplateTags(newTags);
+          // add only 'new' tags
+          final Set<EC2Tag> onlyNewTags = Sets.difference(newTags, existingTags);
+          if (!onlyNewTags.isEmpty()) {
+            final CreateTagsType createTagsType = MessageHelper.createMessage(CreateTagsType.class, newAction.info.getEffectiveUserId());
+            createTagsType.setResourcesSet(Lists.newArrayList(allocationId));
+            createTagsType.setTagSet(EC2Helper.createTagSet(onlyNewTags));
+            compute.createTags(createTagsType);
+          }
+          //  Get old tags...
+          final Set<EC2Tag> oldTags = Sets.newLinkedHashSet();
+          if (oldAction.properties.getTags() != null) {
+            oldTags.addAll(oldAction.properties.getTags());
+          }
+          final List<EC2Tag> oldStackTags = TagHelper.getEC2StackTags(oldAction.getStackEntity());
+          if (oldStackTags != null) {
+            oldTags.addAll(oldStackTags);
+          }
+
+          // remove only the old tags that are not new and that exist
+          final Set<EC2Tag> tagsToRemove = Sets.intersection(oldTags, Sets.difference(existingTags, newTags));
+          if (!tagsToRemove.isEmpty()) {
+            final DeleteTagsType deleteTagsType = MessageHelper.createMessage(DeleteTagsType.class, newAction.info.getEffectiveUserId());
+            deleteTagsType.setResourcesSet(Lists.newArrayList(allocationId));
+            deleteTagsType.setTagSet(EC2Helper.deleteTagSet(tagsToRemove));
+            compute.deleteTags(deleteTagsType);
           }
         }
         return newAction;

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSEC2EIPResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSEC2EIPResourceInfo.java
@@ -50,6 +50,11 @@ public class AWSEC2EIPResourceInfo extends ResourceInfo {
   }
 
   @Override
+  public boolean supportsTags( ) {
+    return true;
+  }
+
+  @Override
   public String toString( ) {
     return MoreObjects.toStringHelper( this )
         .add( "allocationId", allocationId )

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2EIPProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2EIPProperties.java
@@ -28,9 +28,11 @@
  ************************************************************************/
 package com.eucalyptus.cloudformation.resources.standard.propertytypes;
 
+import java.util.ArrayList;
 import com.eucalyptus.cloudformation.resources.ResourceProperties;
 import com.eucalyptus.cloudformation.resources.annotations.Property;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
 
 public class AWSEC2EIPProperties implements ResourceProperties {
 
@@ -39,6 +41,9 @@ public class AWSEC2EIPProperties implements ResourceProperties {
 
   @Property
   private String domain;
+
+  @Property
+  private ArrayList<EC2Tag> tags = Lists.newArrayList( );
 
   public String getDomain( ) {
     return domain;
@@ -56,11 +61,20 @@ public class AWSEC2EIPProperties implements ResourceProperties {
     this.instanceId = instanceId;
   }
 
+  public ArrayList<EC2Tag> getTags( ) {
+    return tags;
+  }
+
+  public void setTags( ArrayList<EC2Tag> tags ) {
+    this.tags = tags;
+  }
+
   @Override
   public String toString( ) {
     return MoreObjects.toStringHelper( this )
         .add( "instanceId", instanceId )
         .add( "domain", domain )
+        .add( "tags", tags )
         .toString( );
   }
 }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/EC2Tag.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/EC2Tag.java
@@ -34,6 +34,14 @@ import com.google.common.base.MoreObjects;
 
 public class EC2Tag {
 
+  public EC2Tag() {
+  }
+
+  public EC2Tag( final String key, final String value ) {
+    this.key = key;
+    this.value = value;
+  }
+
   @Property
   private String key;
 

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/address/AddressManager.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/address/AddressManager.java
@@ -51,8 +51,10 @@ import com.eucalyptus.compute.ClientComputeException;
 import com.eucalyptus.compute.common.AddressInfoType;
 import com.eucalyptus.compute.common.CloudMetadatas;
 import com.eucalyptus.compute.common.internal.address.AddressDomain;
+import com.eucalyptus.compute.common.internal.address.AllocatedAddressEntity;
 import com.eucalyptus.compute.common.internal.identifier.InvalidResourceIdentifier;
 import com.eucalyptus.compute.common.internal.identifier.ResourceIdentifiers;
+import com.eucalyptus.compute.common.internal.tags.Tags;
 import com.eucalyptus.compute.common.internal.util.NotEnoughResourcesException;
 import com.eucalyptus.compute.common.internal.vpc.InternetGateways;
 import com.eucalyptus.compute.common.internal.vpc.NetworkInterface;
@@ -191,6 +193,11 @@ public class AddressManager {
         reply.getAddressesSet( ).add( new AddressInfoType( address.getName( ), AddressDomain.standard.toString(), Principals.nobodyFullName( ).getUserName( ) ) );
       }
     }
+    Tags.populateTags(
+        AccountFullName.getInstance( ctx.getAccountNumber( ) ),
+        AllocatedAddressEntity.class,
+        reply.getAddressesSet( ),
+        AddressInfoType::getAllocationId );
     return reply;
   }
 

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/address/Addresses.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/address/Addresses.java
@@ -64,6 +64,7 @@ import com.eucalyptus.compute.common.internal.address.AddressDomain;
 import com.eucalyptus.compute.common.internal.address.AddressI;
 import com.eucalyptus.compute.common.internal.address.AddressState;
 import com.eucalyptus.compute.common.internal.address.AllocatedAddressEntity;
+import com.eucalyptus.compute.common.internal.address.AllocatedAddressTag;
 import com.eucalyptus.compute.common.internal.vm.VmNetworkConfig;
 import com.eucalyptus.compute.common.internal.vpc.NetworkInterface;
 import com.eucalyptus.entities.PersistenceExceptions;
@@ -956,6 +957,7 @@ public class Addresses {
 
     private static <TI extends AddressI> Builder<TI> properties( final Builder<TI> builder ) {
       return builder
+          .withUnsupportedTagFiltering( Predicates.not( Predicates.instanceOf( Address.class ) ) )
           .withStringProperty( "allocation-id", ALLOCATION_ID )
           .withStringProperty( "association-id", ASSOCIATION_ID )
           .withStringProperty( "domain", DOMAIN )
@@ -976,6 +978,7 @@ public class Addresses {
   public static class AllocatedAddressEntityFilterSupport extends AddressIFilterSupport<AllocatedAddressEntity> {
     public AllocatedAddressEntityFilterSupport ( ) {
       super( builderFor( AllocatedAddressEntity.class )
+          .withTagFiltering( AllocatedAddressTag.class, "allocatedAddress" )
           .withPersistenceFilter( "allocation-id", "allocationId" )
           .withPersistenceFilter( "association-id", "associationId" )
           .withPersistenceFilter( "domain", "domain", FUtils.valueOfFunction( AddressDomain.class ) )

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AddressInfoType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AddressInfoType.java
@@ -31,7 +31,7 @@ package com.eucalyptus.compute.common;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 
-public class AddressInfoType extends EucalyptusData {
+public class AddressInfoType extends EucalyptusData implements ResourceTagged {
 
   private String publicIp;
   private String allocationId;
@@ -41,6 +41,7 @@ public class AddressInfoType extends EucalyptusData {
   private String networkInterfaceId;
   private String networkInterfaceOwnerId;
   private String privateIpAddress;
+  private ResourceTagSetType tagSet = new ResourceTagSetType( );
 
   public AddressInfoType( final String publicIp, final String domain, final String instanceId ) {
     this.publicIp = publicIp;
@@ -113,5 +114,13 @@ public class AddressInfoType extends EucalyptusData {
 
   public void setPrivateIpAddress( String privateIpAddress ) {
     this.privateIpAddress = privateIpAddress;
+  }
+
+  public ResourceTagSetType getTagSet( ) {
+    return tagSet;
+  }
+
+  public void setTagSet( ResourceTagSetType tagSet ) {
+    this.tagSet = tagSet;
   }
 }

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DhcpOptionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DhcpOptionsType.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import com.eucalyptus.util.CompatFunction;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class DhcpOptionsType extends EucalyptusData implements VpcTagged {
+public class DhcpOptionsType extends EucalyptusData implements ResourceTagged {
 
   private String dhcpOptionsId;
   private DhcpConfigurationItemSetType dhcpConfigurationSet;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InternetGatewayType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InternetGatewayType.java
@@ -32,7 +32,7 @@ import com.eucalyptus.util.CompatFunction;
 import com.google.common.base.Strings;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class InternetGatewayType extends EucalyptusData implements VpcTagged {
+public class InternetGatewayType extends EucalyptusData implements ResourceTagged {
 
   private String internetGatewayId;
   private InternetGatewayAttachmentSetType attachmentSet = new InternetGatewayAttachmentSetType( );

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NatGatewayType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NatGatewayType.java
@@ -31,7 +31,7 @@ package com.eucalyptus.compute.common;
 import java.util.Date;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class NatGatewayType extends EucalyptusData implements VpcTagged {
+public class NatGatewayType extends EucalyptusData implements ResourceTagged {
 
   private Date createTime;
   private Date deleteTime;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkAclType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkAclType.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import com.eucalyptus.util.CompatFunction;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class NetworkAclType extends EucalyptusData implements VpcTagged {
+public class NetworkAclType extends EucalyptusData implements ResourceTagged {
 
   private String networkAclId;
   private String vpcId;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfaceType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfaceType.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import com.eucalyptus.util.CompatFunction;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class NetworkInterfaceType extends EucalyptusData implements VpcTagged {
+public class NetworkInterfaceType extends EucalyptusData implements ResourceTagged {
 
   private String networkInterfaceId;
   private String subnetId;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResourceTagged.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResourceTagged.java
@@ -28,7 +28,7 @@
  ************************************************************************/
 package com.eucalyptus.compute.common;
 
-public interface VpcTagged {
+public interface ResourceTagged {
 
   ResourceTagSetType getTagSet( );
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RouteTableType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RouteTableType.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import com.eucalyptus.util.CompatFunction;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class RouteTableType extends EucalyptusData implements VpcTagged {
+public class RouteTableType extends EucalyptusData implements ResourceTagged {
 
   private String routeTableId;
   private String vpcId;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SubnetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SubnetType.java
@@ -31,7 +31,7 @@ package com.eucalyptus.compute.common;
 import com.eucalyptus.util.CompatFunction;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class SubnetType extends EucalyptusData implements VpcTagged {
+public class SubnetType extends EucalyptusData implements ResourceTagged {
 
   private String subnetId;
   private String state;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcType.java
@@ -31,7 +31,7 @@ package com.eucalyptus.compute.common;
 import com.eucalyptus.util.CompatFunction;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
-public class VpcType extends EucalyptusData implements VpcTagged {
+public class VpcType extends EucalyptusData implements ResourceTagged {
 
   private String vpcId;
   private String state;

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-ips-15-04-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-ips-15-04-15.xml
@@ -125,6 +125,7 @@
     <value name="networkInterfaceId" field="networkInterfaceId" usage="optional" />
     <value name="networkInterfaceOwnerId" field="networkInterfaceOwnerId" usage="optional" />
     <value name="privateIpAddress" field="privateIpAddress" usage="optional" />
+    <structure name="tagSet" field="tagSet" usage="optional" type="com.eucalyptus.compute.common.ResourceTagSetType"/>
   </mapping>
   <!-- 2015-04-15 -->
   <mapping name="DescribeMovingAddresses" class="com.eucalyptus.compute.common.DescribeMovingAddressesType"

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
@@ -15,5 +15,11 @@ import com.eucalyptus.component.annotation.ComponentPart;
 @ComponentPart(Compute.class)
 public interface ComputeApi {
 
+  CreateTagsResponseType createTags( CreateTagsType request );
+
+  DeleteTagsResponseType deleteTags( DeleteTagsType request );
+
+  DescribeTagsResponseType describeTags( DescribeTagsType request );
+
   ModifyInstanceTypeAttributeResponseType modifyInstanceType( ModifyInstanceTypeAttributeType request );
 }

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/address/AllocatedAddressEntity.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/address/AllocatedAddressEntity.java
@@ -28,6 +28,7 @@
  ************************************************************************/
 package com.eucalyptus.compute.common.internal.address;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -35,11 +36,14 @@ import java.util.concurrent.Callable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Index;
+import javax.persistence.OneToMany;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
@@ -134,11 +138,10 @@ public class AllocatedAddressEntity extends UserMetadata<AddressState> implement
   @Column( name = "metadata_association_private_address" )
   private String privateAddress;
 
-  protected AllocatedAddressEntity() {}
+  @OneToMany( fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "allocatedAddress" )
+  private Collection<AllocatedAddressTag> tags;
 
-  protected AllocatedAddressEntity( String ipAddress ) {
-    this( Principals.nobodyFullName( ), ipAddress );
-  }
+  protected AllocatedAddressEntity() {}
 
   protected AllocatedAddressEntity( final OwnerFullName owner, final String ipAddress ) {
     super( owner, ipAddress );
@@ -159,14 +162,6 @@ public class AllocatedAddressEntity extends UserMetadata<AddressState> implement
       @Nullable final String ip
   ) {
     return new AllocatedAddressEntity( owner, ip );
-  }
-
-  public static AllocatedAddressEntity exampleWithNaturalId(
-    final String uuid
-  ) {
-    final AllocatedAddressEntity example = new AllocatedAddressEntity( );
-    example.setNaturalId( uuid );
-    return example;
   }
 
   public static AllocatedAddressEntity example() {

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/address/AllocatedAddressTag.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/address/AllocatedAddressTag.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.internal.address;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+import com.eucalyptus.auth.principal.OwnerFullName;
+import com.eucalyptus.compute.common.CloudMetadata;
+import com.eucalyptus.compute.common.internal.tags.Tag;
+import com.eucalyptus.compute.common.internal.tags.TagSupport;
+import com.eucalyptus.compute.common.internal.tags.Tags;
+import com.eucalyptus.entities.Entities;
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+
+/**
+ *
+ */
+@Entity
+@PersistenceContext( name = "eucalyptus_cloud" )
+@Table( name = "metadata_tags_addresses" )
+@DiscriminatorValue( "elastic-ip" )
+public class AllocatedAddressTag extends Tag<AllocatedAddressTag> {
+  private static final long serialVersionUID = 1L;
+
+  @JoinColumn( name = "metadata_tag_resource_id", updatable = false, nullable = false )
+  @ManyToOne( fetch = FetchType.LAZY )
+  private AllocatedAddressEntity allocatedAddress;
+
+  protected AllocatedAddressTag( ) {
+    super( "elastic-ip", ResourceIdFunction.INSTANCE );
+  }
+
+  public AllocatedAddressTag( @Nonnull final AllocatedAddressEntity allocatedAddress,
+                              @Nonnull final OwnerFullName ownerFullName,
+                              @Nullable final String key,
+                              @Nullable final String value ) {
+    super( "elastic-ip", ResourceIdFunction.INSTANCE, ownerFullName, key, value );
+    setAllocatedAddress( allocatedAddress );
+    init();
+  }
+
+  public AllocatedAddressEntity getAllocatedAddress( ) {
+    return allocatedAddress;
+  }
+
+  public void setAllocatedAddress( final AllocatedAddressEntity allocatedAddress ) {
+    this.allocatedAddress = allocatedAddress;
+  }
+
+  @Nonnull
+  public static Tag named( @Nonnull final AllocatedAddressEntity allocatedAddress,
+                           @Nonnull final OwnerFullName ownerFullName,
+                           @Nullable final String key ) {
+    return namedWithValue( allocatedAddress, ownerFullName, key, null );
+  }
+
+  @Nonnull
+  public static Tag namedWithValue( @Nonnull final AllocatedAddressEntity allocatedAddress,
+                                    @Nonnull final OwnerFullName ownerFullName,
+                                    @Nullable final String key,
+                                    @Nullable final String value ) {
+    Preconditions.checkNotNull( allocatedAddress, "allocatedAddress" );
+    Preconditions.checkNotNull( ownerFullName, "ownerFullName" );
+    return new AllocatedAddressTag( allocatedAddress, ownerFullName, key, value );
+  }
+
+  private enum ResourceIdFunction implements Function<AllocatedAddressTag,String> {
+    INSTANCE {
+      @Override
+      public String apply( final AllocatedAddressTag allocatedAddressTag ) {
+        return allocatedAddressTag.getAllocatedAddress( ).getAllocationId( );
+      }
+    }
+  }
+
+  public static final class AllocatedAddressTagSupport extends TagSupport {
+    public AllocatedAddressTagSupport() {
+      super( AllocatedAddressEntity.class,
+          "eipalloc",
+          "allocationId",
+          "allocatedAddress",
+          "InvalidAllocationID.NotFound",
+          "The address allocation '%s' does not exist." );
+    }
+
+    @Override
+    public Tag createOrUpdate(
+        final CloudMetadata metadata,
+        final OwnerFullName ownerFullName,
+        final String key,
+        final String value ) {
+      return Tags.createOrUpdate(
+          new AllocatedAddressTag( (AllocatedAddressEntity) metadata, ownerFullName, key, value ) );
+    }
+
+    @Override
+    public Tag example( @Nonnull final CloudMetadata metadata,
+                        @Nonnull final OwnerFullName ownerFullName,
+                        final String key,
+                        final String value ) {
+      return AllocatedAddressTag.namedWithValue( (AllocatedAddressEntity) metadata, ownerFullName, key, value );
+    }
+
+    @Override
+    public Tag example( @Nonnull final OwnerFullName ownerFullName ) {
+      return example( new AllocatedAddressTag( ), ownerFullName );
+    }
+
+    @Override
+    public CloudMetadata lookup( final String identifier ) {
+      return Entities.criteriaQuery( AllocatedAddressEntity.class )
+          .whereEqual( AllocatedAddressEntity_.allocationId, identifier )
+          .uniqueResult( );
+    }
+  }
+}

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/tags/Filter.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/tags/Filter.java
@@ -49,28 +49,23 @@ public class Filter {
   @Nonnull private final Map<String,String> aliases;
   @Nonnull private final Criterion criterion;
   @Nonnull private final Predicate<Object> predicate;
-  private final boolean filteringOnTags;
-  
+
   Filter( @Nonnull final Map<String,String> aliases,
           @Nonnull final Criterion criterion,
-          @Nonnull final Predicate<Object> predicate,
-          final boolean filteringOnTags ) {
+          @Nonnull final Predicate<Object> predicate ) {
     this.aliases = aliases;
     this.criterion = criterion;
     this.predicate = predicate;
-    this.filteringOnTags = filteringOnTags;
   }
 
-  Filter( @Nonnull final Predicate<Object> predicate,
-          final boolean filteringOnTags ) {
+  Filter( @Nonnull final Predicate<Object> predicate ) {
     this( Collections.<String,String>emptyMap(),
         Restrictions.conjunction(),
-        predicate,
-        filteringOnTags );
+        predicate);
   }
   
   private Filter() {
-    this( Predicates.alwaysTrue(), false );
+    this( Predicates.alwaysTrue() );
   }
 
   /**
@@ -115,15 +110,6 @@ public class Filter {
   }
 
   /**
-   * Does the filter use tags?
-   *
-   * @return True if the filter uses any tags
-   */
-  public boolean isFilteringOnTags() {
-    return filteringOnTags;
-  }
-
-  /**
    * Create a Filter that will always pass (filters out nothing)
    */
   static Filter alwaysTrue() {
@@ -146,8 +132,7 @@ public class Filter {
     return new Filter(
       aliases,
       and,
-      Predicates.and( this.predicate, filter.predicate ),
-      this.filteringOnTags || filter.filteringOnTags
+      Predicates.and( this.predicate, filter.predicate )
     );
   }
 }


### PR DESCRIPTION
EC2 and CloudFormation support for elastic ip (allocation) tagging for vpc platform. Resource tagging / filtering is supported but there are not currently an resource based permissions for elastic ips. CloudFormation stacks will now tag elastic ips with the usual system tags and allow create/update of user tags.