### PR TITLE
YAML format support for network and region configuration

### DIFF
--- a/admin-tools/eucalyptus_admin/commands/properties/euctl.py
+++ b/admin-tools/eucalyptus_admin/commands/properties/euctl.py
@@ -43,9 +43,9 @@ from eucalyptus_admin.commands.properties.modifypropertyvalue import \
     ModifyPropertyValue
 
 
-PROPERTY_TYPES = {'authentication.ldap_integration_configuration': 'json',
-                  'cloud.network.network_configuration': 'json',
-                  'region.region_configuration': 'json'}
+PROPERTY_TYPES = {'authentication.ldap_integration_configuration': ['json'],
+                  'cloud.network.network_configuration': ['json', 'yaml'],
+                  'region.region_configuration': ['json', 'yaml']}
 
 
 def _property_key_value(kvp_str):
@@ -125,7 +125,7 @@ class Euctl(PropertiesRequest):
                     editor, vi(1).'''),
                 Arg('--dump', action='store_true', help='''Output the value of
                     a structure variable in its entirety.''')),
-            Arg('--format', choices=('json', 'yaml', 'raw'), default='json',
+            Arg('--format', choices=('json', 'yaml', 'raw'),
                 help='''Try to use the specified format when displaying
                 a structure variable.  "raw" is only allowed with --dump.
                 (default: json)''')]
@@ -137,7 +137,7 @@ class Euctl(PropertiesRequest):
             argcheck = '--dump'
         elif self.args.get('edit'):
             argcheck = '--edit'
-            if self.args.get('format') == 'raw':
+            if self.args.get('format', 'json') == 'raw':
                 raise ArgumentError(
                     'argument --format: "raw" is only allowed with --dump')
         if argcheck:
@@ -159,7 +159,7 @@ class Euctl(PropertiesRequest):
         if self.args.get('dump'):
             prop_name = self.args.get('prop_pairs')[0][0]
             self.log.info('dumping property value   %s', prop_name)
-            if self.args.get('format') == 'raw':
+            if self.args.get('format', 'json') == 'raw':
                 # We need to actively prevent this from being parsed.
                 prop_type = _Property
             else:
@@ -307,32 +307,45 @@ class Euctl(PropertiesRequest):
 
     def _get_formatter(self, prop):
         formatter = None
-        if self.args.get('format') == 'raw':
+        if self.args.get('format', None) == 'raw':
             formatter = _Formatter()
-        if self.args.get('format') == 'json':
+        if self.args.get('format', None) == 'json':
             formatter = _JSONFormatter()
-        if self.args.get('format') == 'yaml':
+        if self.args.get('format', None) == 'yaml':
             formatter = _YAMLFormatter()
         if isinstance(prop, _FallbackProperty):
             print >> sys.stderr, 'warning: existing value of', prop.name, \
                 'is malformed; outputting it as raw text'
             return _FallbackFormatter(formatter)
+        if not formatter:
+            formatter = prop.formatter()
         if formatter:
             return formatter
         raise NotImplementedError('formatter "{0}" not implemented'
-                                  .format(self.args.get('format')))
+                                  .format(self.args.get('format', 'json')))
 
 
 def _build_property(prop_name, prop_value, prop_type=None, log=None):
     if prop_type:
-        prop = prop_type(prop_name)
-    elif PROPERTY_TYPES.get(prop_name) == 'json':
-        prop = _JSONProperty(prop_name)
+        props = [prop_type(prop_name)]
+    elif PROPERTY_TYPES.get(prop_name, None):
+        props = []
+        for property_type in PROPERTY_TYPES.get(prop_name):
+            if property_type == 'json':
+                props.append(_JSONProperty(prop_name))
+            elif property_type == 'yaml':
+                props.append(_YAMLProperty(prop_name))
     else:
-        prop = _Property(prop_name)
-    try:
-        prop.loads(prop_value)
-    except (ValueError, yaml.error.YAMLError):
+        props = [_Property(prop_name)]
+    prop = None
+    for cprop in props:
+        try:
+            cprop.loads(prop_value)
+            prop = cprop
+            break
+        except (ValueError, yaml.error.YAMLError):
+            pass
+    if not prop:
         if log:
             log.warn('parsing of variable %s failed; --dump or --edit will '
                      'output it as raw text', prop_name, exc_info=True)
@@ -420,6 +433,9 @@ class _Property(object):
     def load(self, fileobj):
         self.loads(fileobj.read())
 
+    def formatter(self):
+        return self._formatter
+
     def print_(self, suppress_name=False, force=False):
         if self.value == {}:
             value = ''
@@ -433,6 +449,15 @@ class _Property(object):
 
 class _JSONProperty(_Property):
     FORMATTER = _JSONFormatter
+
+    def print_(self, suppress_name=False, force=False):
+        if force:
+            print >> sys.stderr, 'use euctl --dump to view {0}'.format(
+                self.name)
+
+
+class _YAMLProperty(_Property):
+    FORMATTER = _YAMLFormatter
 
     def print_(self, suppress_name=False, force=False):
         if force:

--- a/clc/modules/compute-backend/src/test/java/com/eucalyptus/network/config/NetworkConfigurationTest.groovy
+++ b/clc/modules/compute-backend/src/test/java/com/eucalyptus/network/config/NetworkConfigurationTest.groovy
@@ -117,6 +117,71 @@ class NetworkConfigurationTest {
   }
 
   @Test
+  void testYamlFullParse() {
+    String config = """
+      Mode: EDGE
+      InstanceDnsDomain: eucalyptus.internal
+      InstanceDnsServers:
+        - "1.2.3.4"
+      MacPrefix: d0:0d
+      PublicIps:
+        - "10.111.200.1-10.111.200.2"
+      PublicGateway: "10.111.0.1"
+      PrivateIps:
+        - "1.0.0.33-1.0.0.34"
+      Subnets:
+        - Name: "1.0.0.0"
+          Subnet: "1.0.0.0"
+          Netmask: "255.255.0.0"
+          Gateway: "1.0.0.1"
+      Clusters:
+        - Name: edgecluster0
+          MacPrefix: d0:0d
+          Subnet:
+            Name: "1.0.0.0"
+            Subnet: "1.0.0.0"
+            Netmask: "255.255.0.0"
+            Gateway: "1.0.0.1"
+          PrivateIps:
+            - "1.0.0.33"
+            - "1.0.0.34"
+    """.stripIndent()
+
+    NetworkConfigurationApi.NetworkConfiguration result = NetworkConfigurations.parse( config )
+    println result
+
+    NetworkConfigurationApi.NetworkConfiguration expected = ImmutableNetworkConfigurationApi.NetworkConfiguration.builder( )
+        .mode('EDGE')
+        .instanceDnsDomain('eucalyptus.internal')
+        .instanceDnsServer('1.2.3.4')
+        .macPrefix('d0:0d')
+        .publicIp('10.111.200.1-10.111.200.2')
+        .publicGateway('10.111.0.1')
+        .privateIp('1.0.0.33-1.0.0.34')
+        .subnet(ImmutableNetworkConfigurationApi.EdgeSubnet.builder( )
+        .name('1.0.0.0')
+        .subnet('1.0.0.0')
+        .netmask('255.255.0.0')
+        .gateway('1.0.0.1')
+        .o( ) )
+        .cluster(ImmutableNetworkConfigurationApi.Cluster.builder( )
+        .name('edgecluster0')
+        .macPrefix('d0:0d')
+        .subnet(ImmutableNetworkConfigurationApi.EdgeSubnet.builder( )
+        .name('1.0.0.0')
+        .subnet('1.0.0.0')
+        .netmask('255.255.0.0')
+        .gateway('1.0.0.1')
+        .o( ) )
+        .privateIp('1.0.0.33')
+        .privateIp('1.0.0.34')
+        .o( ) )
+        .o( )
+
+    assertEquals( 'Result does not match template', expected, result )
+  }
+
+  @Test
   void testMinimalTopLevelParse() {
     String config = """
     {

--- a/clc/modules/euare/src/test/java/com/eucalyptus/auth/euare/identity/region/RegionConfigurationTest.groovy
+++ b/clc/modules/euare/src/test/java/com/eucalyptus/auth/euare/identity/region/RegionConfigurationTest.groovy
@@ -102,6 +102,54 @@ class RegionConfigurationTest {
     assertEquals( 'Result does not match template', expected, result)
   }
 
+  @Test
+  void testYamlFullParse() {
+    String config = """
+      Regions:
+        - Name: region-1
+          CertificateFingerprint: EC:E7:3D:DF:97:43:00:9E:FC:F0:2C:6D:98:D2:82:EB:AA:04:75:10:E7:C2:F2:6F:31:F1:F1:CA:A1:61:DE:41
+          IdentifierPartitions:
+            - 1
+          Services:
+            - Type: identity
+              Endpoints:
+                - https://identity.example.com:8773/services/Identity
+          RemoteCidrs:
+            - "1.0.0.0/32"
+          ForwardedForCidrs:
+            - "1.0.0.0/32"
+      RemoteCidrs:
+         - "1.0.0.0/32"
+      ForwardedForCidrs:
+         - "1.0.0.0/32"
+    """.stripIndent()
+
+    RegionConfiguration result = RegionConfigurations.parse( config )
+    println result
+
+    RegionConfiguration expected = new RegionConfiguration(
+        regions: [
+            new Region(
+                name: 'region-1',
+                certificateFingerprint: 'EC:E7:3D:DF:97:43:00:9E:FC:F0:2C:6D:98:D2:82:EB:AA:04:75:10:E7:C2:F2:6F:31:F1:F1:CA:A1:61:DE:41',
+                identifierPartitions: [ 1 ],
+                services: [
+                    new Service(
+                        type: 'identity',
+                        endpoints: [ 'https://identity.example.com:8773/services/Identity' ]
+                    )
+                ],
+                remoteCidrs: [ "1.0.0.0/32" ],
+                forwardedForCidrs: [ "1.0.0.0/32" ]
+            )
+        ],
+        remoteCidrs: [ "1.0.0.0/32" ],
+        forwardedForCidrs: [ "1.0.0.0/32" ]
+    )
+
+    assertEquals( 'Result does not match template', expected, result)
+  }
+
   @Test( expected = RegionConfigurationException )
   void testInvalidRegion( ) {
     String config =  """


### PR DESCRIPTION
JSON or YAML can now be used for network and region configuration cloud properties:

```
cloud.network.network_configuration
region.region_configuration
```

The `--format` option for `euctl` can be used to convert between JSON and YAML formats, e.g.:

```
# euctl --dump --format=yaml region.region_configuration > regions.yaml
```