### PR TITLE
Use SPDX short licence identifers in source files

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceTypeResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceTypeResourceAction.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cloudformation.resources.standard.actions;
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSEC2InstanceTypeResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSEC2InstanceTypeResourceInfo.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cloudformation.resources.standard.info;
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2InstanceTypeProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2InstanceTypeProperties.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cloudformation.resources.standard.propertytypes;
 

--- a/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/proxy/ProxyClusterBootstrapper.java
+++ b/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/proxy/ProxyClusterBootstrapper.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cluster.proxy;
 

--- a/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/proxy/ProxyClusterServiceImpl.java
+++ b/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/proxy/ProxyClusterServiceImpl.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cluster.proxy;
 

--- a/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/ClusterFullService.java
+++ b/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/ClusterFullService.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cluster.service;
 

--- a/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/ClusterServiceEnv.java
+++ b/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/ClusterServiceEnv.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cluster.service;
 

--- a/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/node/ClusterNodeRuntimeException.java
+++ b/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/node/ClusterNodeRuntimeException.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.cluster.service.node;
 

--- a/clc/modules/compute-backend/src/test/java/com/eucalyptus/vm/InstanceTypesTemplateGenerator.groovy
+++ b/clc/modules/compute-backend/src/test/java/com/eucalyptus/vm/InstanceTypesTemplateGenerator.groovy
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.vm
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AcceptVpcEndpointConnectionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AcceptVpcEndpointConnectionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AcceptVpcEndpointConnectionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AcceptVpcEndpointConnectionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ActiveInstance.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ActiveInstance.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ActiveInstanceSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ActiveInstanceSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AllowedPrincipal.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AllowedPrincipal.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AllowedPrincipalSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AllowedPrincipalSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ConnectionNotification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ConnectionNotification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ConnectionNotificationSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ConnectionNotificationSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CopyFpgaImageResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CopyFpgaImageResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CopyFpgaImageType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CopyFpgaImageType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultSubnetResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultSubnetResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultSubnetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultSubnetType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultVpcResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultVpcResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultVpcType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateDefaultVpcType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFleetResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFleetResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFleetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFleetType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFpgaImageResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFpgaImageResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFpgaImageType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateFpgaImageType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateVersionResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateVersionResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateVersionType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateLaunchTemplateVersionType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateNetworkInterfacePermissionResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateNetworkInterfacePermissionResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateNetworkInterfacePermissionType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateNetworkInterfacePermissionType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointConnectionNotificationResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointConnectionNotificationResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointConnectionNotificationType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointConnectionNotificationType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointServiceConfigurationResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointServiceConfigurationResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointServiceConfigurationType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreateVpcEndpointServiceConfigurationType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreditSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreditSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreditSpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/CreditSpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetError.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetError.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetErrorItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetErrorItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetErrorSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetErrorSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetSuccessItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetSuccessItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetSuccessSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetSuccessSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFleetsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFpgaImageResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFpgaImageResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFpgaImageType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteFpgaImageType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseErrorItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseErrorItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseErrorSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseErrorSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseSuccessItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseSuccessItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseSuccessSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseSuccessSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteLaunchTemplateVersionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteNetworkInterfacePermissionResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteNetworkInterfacePermissionResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteNetworkInterfacePermissionType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteNetworkInterfacePermissionType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointConnectionNotificationsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointConnectionNotificationsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointConnectionNotificationsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointConnectionNotificationsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointServiceConfigurationsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointServiceConfigurationsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointServiceConfigurationsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DeleteVpcEndpointServiceConfigurationsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeAggregateIdFormatResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeAggregateIdFormatResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeAggregateIdFormatType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeAggregateIdFormatType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeElasticGpusResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeElasticGpusResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeElasticGpusType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeElasticGpusType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetHistoryResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetHistoryResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetHistoryType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetHistoryType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetInstancesResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetInstancesResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetInstancesType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetInstancesType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFleetsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImageAttributeResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImageAttributeResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImageAttributeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImageAttributeType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImagesResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImagesResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImagesType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeFpgaImagesType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeInstanceCreditSpecificationsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeInstanceCreditSpecificationsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeInstanceCreditSpecificationsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeInstanceCreditSpecificationsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplateVersionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplateVersionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplateVersionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplateVersionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplatesResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplatesResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplatesType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeLaunchTemplatesType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeNetworkInterfacePermissionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeNetworkInterfacePermissionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeNetworkInterfacePermissionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeNetworkInterfacePermissionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribePrincipalIdFormatResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribePrincipalIdFormatResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribePrincipalIdFormatType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribePrincipalIdFormatType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVolumesModificationsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVolumesModificationsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVolumesModificationsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVolumesModificationsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionNotificationsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionNotificationsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionNotificationsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionNotificationsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointConnectionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServiceConfigurationsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServiceConfigurationsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServiceConfigurationsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServiceConfigurationsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServicePermissionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServicePermissionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServicePermissionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcEndpointServicePermissionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuHealth.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuHealth.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuIdSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuIdSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecificationList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecificationList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecificationResponse.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecificationResponse.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecificationResponseList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpuSpecificationResponseList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpus.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ElasticGpus.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/EventInformation.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/EventInformation.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetData.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetData.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetIdSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetIdSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfig.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfig.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfigList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfigList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfigListRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfigListRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfigRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateConfigRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverrides.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverrides.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverridesList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverridesList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverridesListRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverridesListRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverridesRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateOverridesRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateSpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetLaunchTemplateSpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FleetSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImage.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImage.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageAttribute.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageAttribute.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageIdList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageIdList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageState.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/FpgaImageState.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/GetLaunchTemplateDataResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/GetLaunchTemplateDataResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/GetLaunchTemplateDataType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/GetLaunchTemplateDataType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/GroupIdStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/GroupIdStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/HistoryRecordEntry.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/HistoryRecordEntry.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/HistoryRecordSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/HistoryRecordSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/IamInstanceProfileAssociation.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/IamInstanceProfileAssociation.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/IamInstanceProfileAssociationSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/IamInstanceProfileAssociationSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/IdFormatList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/IdFormatList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecificationList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecificationList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecificationListRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecificationListRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceCreditSpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIdStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIdStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6Address.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6Address.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6AddressList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6AddressList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6AddressListRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6AddressListRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6AddressRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/InstanceIpv6AddressRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplate.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplate.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMapping.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMapping.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMappingList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMappingList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMappingRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMappingRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMappingRequestList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateBlockDeviceMappingRequestList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateConfig.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateConfig.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateConfigList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateConfigList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateCpuOptions.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateCpuOptions.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateCpuOptionsRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateCpuOptionsRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateEbsBlockDevice.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateEbsBlockDevice.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateEbsBlockDeviceRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateEbsBlockDeviceRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateIamInstanceProfileSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateIamInstanceProfileSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateIamInstanceProfileSpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateIamInstanceProfileSpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceMarketOptions.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceMarketOptions.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceMarketOptionsRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceMarketOptionsRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecificationList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecificationList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecificationRequestList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateInstanceNetworkInterfaceSpecificationRequestList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateNameStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateNameStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateOverrides.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateOverrides.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateOverridesList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateOverridesList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatePlacement.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatePlacement.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatePlacementRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatePlacementRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSpotMarketOptions.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSpotMarketOptions.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSpotMarketOptionsRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateSpotMarketOptionsRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecificationList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecificationList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecificationRequestList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateTagSpecificationRequestList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateVersion.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateVersion.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateVersionSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplateVersionSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatesMonitoring.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatesMonitoring.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatesMonitoringRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LaunchTemplatesMonitoringRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermission.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermission.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionListRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionListRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionModifications.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionModifications.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/LoadPermissionRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFleetResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFleetResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFleetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFleetType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFpgaImageAttributeResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFpgaImageAttributeResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFpgaImageAttributeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyFpgaImageAttributeType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceCreditSpecificationResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceCreditSpecificationResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceCreditSpecificationType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceCreditSpecificationType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyLaunchTemplateResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyLaunchTemplateResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyLaunchTemplateType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyLaunchTemplateType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVolumeResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVolumeResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVolumeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVolumeType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointConnectionNotificationResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointConnectionNotificationResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointConnectionNotificationType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointConnectionNotificationType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServiceConfigurationResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServiceConfigurationResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServiceConfigurationType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServiceConfigurationType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServicePermissionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServicePermissionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServicePermissionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcEndpointServicePermissionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcTenancyResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcTenancyResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcTenancyType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVpcTenancyType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermission.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermission.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermissionIdList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermissionIdList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermissionList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermissionList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermissionState.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/NetworkInterfacePermissionState.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/OnDemandOptions.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/OnDemandOptions.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/OnDemandOptionsRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/OnDemandOptionsRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/OwnerStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/OwnerStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PciId.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PciId.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrincipalIdFormat.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrincipalIdFormat.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrincipalIdFormatList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrincipalIdFormatList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrivateIpAddressSpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrivateIpAddressSpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrivateIpAddressSpecificationList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/PrivateIpAddressSpecificationList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ProductCode.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ProductCode.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ProductCodeList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ProductCodeList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ProductCodeStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ProductCodeStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RejectVpcEndpointConnectionsResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RejectVpcEndpointConnectionsResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RejectVpcEndpointConnectionsType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RejectVpcEndpointConnectionsType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RequestLaunchTemplateData.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/RequestLaunchTemplateData.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResetFpgaImageAttributeResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResetFpgaImageAttributeResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResetFpgaImageAttributeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResetFpgaImageAttributeType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResourceList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResourceList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResponseError.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResponseError.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResponseLaunchTemplateData.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ResponseLaunchTemplateData.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SecurityGroupIdStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SecurityGroupIdStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SecurityGroupStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SecurityGroupStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceConfiguration.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceConfiguration.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceConfigurationSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceConfigurationSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceTypeDetail.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceTypeDetail.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceTypeDetailSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ServiceTypeDetailSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SpotOptions.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SpotOptions.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SpotOptionsRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SpotOptionsRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/StorageLocation.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/StorageLocation.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SuccessfulInstanceCreditSpecificationItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SuccessfulInstanceCreditSpecificationItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SuccessfulInstanceCreditSpecificationSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SuccessfulInstanceCreditSpecificationSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/TargetCapacitySpecification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/TargetCapacitySpecification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/TargetCapacitySpecificationRequest.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/TargetCapacitySpecificationRequest.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulInstanceCreditSpecificationItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulInstanceCreditSpecificationItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulInstanceCreditSpecificationItemError.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulInstanceCreditSpecificationItemError.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulInstanceCreditSpecificationSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulInstanceCreditSpecificationSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulItem.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulItem.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulItemError.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulItemError.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulItemSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UnsuccessfulItemSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsEgressResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsEgressResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsEgressType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsEgressType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsIngressResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsIngressResponseType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsIngressType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UpdateSecurityGroupRuleDescriptionsIngressType.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UserGroupStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UserGroupStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UserIdStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/UserIdStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ValueStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ValueStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VersionStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VersionStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VolumeIdStringList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VolumeIdStringList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VolumeModification.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VolumeModification.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VolumeModificationList.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VolumeModificationList.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcEndpointConnection.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcEndpointConnection.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcEndpointConnectionSet.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcEndpointConnectionSet.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common;
 

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/address/AllocatedAddressTag.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/address/AllocatedAddressTag.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common.internal.address;
 

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/network/NetworkCidr.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/network/NetworkCidr.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common.internal.network;
 

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmIamInstanceProfileHelper.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmIamInstanceProfileHelper.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common.internal.vm;
 

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vpc/NatGatewayTag.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vpc/NatGatewayTag.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.compute.common.internal.vpc;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/BindingBootstrap.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/BindingBootstrap.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpContent.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpContent.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpHeaderMapping.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpHeaderMapping.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpNoContent.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpNoContent.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpRequestMapping.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpRequestMapping.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpUriMapping.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/HttpUriMapping.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/binding/RestBinding.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/binding/RestBinding.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.binding;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/util/Yaml.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/Yaml.java
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.util;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/DelegatingChannel.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/DelegatingChannel.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/DelegatingChannelHandlerContext.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/DelegatingChannelHandlerContext.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/protocol/BaseJsonBinding.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/protocol/BaseJsonBinding.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.protocol;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/protocol/BaseRestJsonBinding.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/protocol/BaseRestJsonBinding.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.protocol;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/protocol/BaseRestXmlBinding.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/protocol/BaseRestXmlBinding.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.protocol;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/server/JsonPipeline.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/server/JsonPipeline.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.server;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/server/RestJsonPipeline.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/server/RestJsonPipeline.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.server;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/server/RestPipeline.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/server/RestPipeline.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.server;
 

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/server/RestXmlPipeline.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/server/RestXmlPipeline.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.ws.server;
 

--- a/clc/modules/core/src/test/java/com/eucalyptus/util/YamlTest.groovy
+++ b/clc/modules/core/src/test/java/com/eucalyptus/util/YamlTest.groovy
@@ -1,9 +1,7 @@
 /*
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.util
 

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingJsonDataConverter.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingJsonDataConverter.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.loadbalancing.workflow;
 

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/exceptions/s3/AccessDeniedOnCreateException.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/exceptions/s3/AccessDeniedOnCreateException.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.objectstorage.exceptions.s3;
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/GenericProviderClient.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/GenericProviderClient.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.objectstorage.providers.s3;
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/MinioProviderClient.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/MinioProviderClient.java
@@ -1,9 +1,7 @@
 /**
  * Copyright 2018 AppScale Systems, Inc
  *
- * Use of this source code is governed by a BSD-2-Clause
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/BSD-2-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 package com.eucalyptus.objectstorage.providers.s3;
 

--- a/tools/clcadmin-release-credentials
+++ b/tools/clcadmin-release-credentials
@@ -2,9 +2,7 @@
 #
 # Copyright 2018 AppScale Systems, Inc
 #
-# Use of this source code is governed by a BSD-2-Clause
-# license that can be found in the LICENSE file or at
-# https://opensource.org/licenses/BSD-2-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 
 """
 %(prog)s clears environment credentials for administrative impersonation


### PR DESCRIPTION
Switching to SPDX short identifiers instead of previous notice:
```
# Use of this source code is governed by a BSD-2-Clause
# license that can be found in the LICENSE file or at
# https://opensource.org/licenses/BSD-2-Clause
```
now using:
```
# SPDX-License-Identifier: BSD-2-Clause
```
As per SPDX specification 2.1 `Appendix V: Using SPDX short identifiers in Source Files`:
https://spdx.org/spdx-specification-21-web-version#h.twlc0ztnng3b